### PR TITLE
Model & Config updates for the Abrams.

### DIFF
--- a/Addons/ADF_Tracked/adfrc_abrams/c_ammo.hpp
+++ b/Addons/ADF_Tracked/adfrc_abrams/c_ammo.hpp
@@ -1,4 +1,5 @@
-class cfgCloudlets {
+class cfgCloudlets 
+{
 	class MachineGunCartridge;
 	class MachineGunEject;
 	class ADFRC_abrams_cartridge: MachineGunCartridge 
@@ -30,7 +31,8 @@ class cfgCloudlets {
 		bounceOnSurface=0.25;
 	};
 };
-class ADFRC_mag58_casingeject {
+class ADFRC_mag58_casingeject 
+{
 	class MachineGunEject {
 		simulation = "particles";
 		type = "ADFRC_abrams_mag58_cartridge";
@@ -40,7 +42,8 @@ class ADFRC_mag58_casingeject {
 		lifeTime = 0.05;
 	};
 };
-class ADFRC_mag58_linkeject {
+class ADFRC_mag58_linkeject 
+{
 	class MachineGunEject {
 		simulation = "particles";
 		type = "ADFRC_abrams_mag58_eject";
@@ -50,77 +53,365 @@ class ADFRC_mag58_linkeject {
 		lifeTime = 0.05;
 	};
 };
+class Mode_SemiAuto;
+class Mode_Burst;
+class Mode_FullAuto;
 class cfgAmmo
 {
-	class B_762x54_Tracer_Green;
-	class ADFRC_abrams_762x51_Tracer: B_762x54_Tracer_Green
+	
+    //*
+    //* Imports
+    //*
+	
+	class Sh_120mm_APFSDS;
+    class Sh_120mm_HEAT_MP;
+	class Sh_120mm_HE;
+	class B_762x54_Tracer_Red;
+    class B_12Gauge_Pellets_Submunition_Deploy;
+		
+	//*
+    //* 120mm
+    //*
+	
+	class adfrc_abrams_120mm_M829A2_APFSDS: Sh_120mm_APFSDS ///Armour-Piercing Fin-Stabilized Discarding Sabot
 	{
-		model = "\A3\Weapons_f\Data\bullettracer\tracer_red";
-		tracerColor[] = {0.7,0.7,0.5,0.04};
-		tracerColorR[] = {0.7,0.7,0.5,0.04};
+		hit = 500;
+		indirectHit = 15;
+		indirectHitRange = 0.5;
+		warheadName = "AP";
+		dangerRadiusHit = 100;
+		suppressionRadiusHit = 18;
+		explosive = 0;
+		cost = 500;
+		airFriction = -3.96e-05;
+		CraterEffects = "ExploAmmoCrater";
+		explosionEffects = "ExploAmmoExplosion";
+		typicalSpeed = 1550;
+		caliber = 35.2688;
+		deflecting = 15;
+		timeToLive = 15;
+		whistleOnFire = 1;
+		whistleDist = 14;
+		model = "\A3\Weapons_f\Data\bullettracer\shell_tracer_red";
+		tracerScale = 3;
+		tracerStartTime = 0.1;
+		tracerEndTime = 3.0;
+		muzzleEffect = "";
+		soundHit1[] = {"A3\Sounds_F\arsenal\explosives\shells\Tank_shell_explosion_01",1.7782794,1,1800};
+		soundHit2[] = {"A3\Sounds_F\arsenal\explosives\shells\Tank_shell_explosion_02",1.7782794,1,1800};
+		soundHit3[] = {"A3\Sounds_F\arsenal\explosives\shells\Tank_shell_explosion_03",1.7782794,1,1800};
+		soundHit4[] = {"A3\Sounds_F\arsenal\explosives\shells\Tank_shell_explosion_04",1.7782794,1,1800};
+		multiSoundHit[] = {"soundHit1",0.25,"soundHit2",0.25,"soundHit3",0.25,"soundHit4",0.25};
+		aiAmmoUsageFlags = "128 + 512";
+		class CamShakeExplode
+		{
+			power = 13.4164;
+			duration = 2.6;
+			frequency = 20;
+			distance = 40.2492;
+		};
+		class CamShakeHit
+		{
+			power = 180;
+			duration = 0.8;
+			frequency = 20;
+			distance = 1;
+		};
+		class CamShakeFire
+		{
+			power = 3.30975;
+			duration = 2.2;
+			frequency = 20;
+			distance = 87.6356;
+		};
+		class CamShakePlayerFire
+		{
+			power = 0.02;
+			duration = 0.1;
+			frequency = 20;
+			distance = 1;
+		};
+	};
+	class adfrc_abrams_120mm_M830A1_HEATMP: Sh_120mm_HEAT_MP ///High Explosive Anti-Tank
+	{
+		hit = 95;
+		warheadName = "HE";
+		submunitionAmmo = "ammo_Penetrator_120mm";
+		submunitionDirectionType = "SubmunitionModelDirection";
+		submunitionInitSpeed = 1000;
+		submunitionParentSpeedCoef = 0.0;
+		submunitionInitialOffset[] = {0,0,-0.2};
+		triggerOnImpact = 1;
+		deleteParentWhenTriggered = 0;
+		indirectHit = 30;
+		indirectHitRange = 3.5;
+		dangerRadiusHit = 160;
+		suppressionRadiusHit = 32;
+		typicalSpeed = 1400;
+		explosive = 1;
+		cost = 500;
+		airFriction = -0.000275;
+		deflecting = 8;
+		timeToLive = 15;
+		whistleOnFire = 1;
+		whistleDist = 14;
+		model = "\A3\Weapons_f\Data\bullettracer\shell_tracer_red";
+		tracerScale = 1;
+		tracerStartTime = 0.1;
+		tracerEndTime = 3.0;
+		muzzleEffect = "";
+		soundHit1[] = {"A3\Sounds_F\arsenal\explosives\shells\Tank_shell_explosion_01",1.7782794,1,1800};
+		soundHit2[] = {"A3\Sounds_F\arsenal\explosives\shells\Tank_shell_explosion_02",1.7782794,1,1800};
+		soundHit3[] = {"A3\Sounds_F\arsenal\explosives\shells\Tank_shell_explosion_03",1.7782794,1,1800};
+		soundHit4[] = {"A3\Sounds_F\arsenal\explosives\shells\Tank_shell_explosion_04",1.7782794,1,1800};
+		multiSoundHit[] = {"soundHit1",0.25,"soundHit2",0.25,"soundHit3",0.25,"soundHit4",0.25};
+		class CamShakeExplode
+		{
+			power = 24;
+			duration = 2.2;
+			frequency = 20;
+			distance = 143.636;
+		};
+		class CamShakeHit
+		{
+			power = 120;
+			duration = 0.6;
+			frequency = 20;
+			distance = 1;
+		};
+		class CamShakeFire
+		{
+			power = 3.30975;
+			duration = 2.2;
+			frequency = 20;
+			distance = 87.6356;
+		};
+		class CamShakePlayerFire
+		{
+			power = 0.02;
+			duration = 0.1;
+			frequency = 20;
+			distance = 1;
+		};
+		CraterEffects = "ATRocketCrater";
+		explosionEffects = "ATRocketExplosion";
+		explosionSoundEffect = "DefaultExplosion";
+	};
+	class adfrc_abrams_120mm_M908_HE: Sh_120mm_HE ///High Explosive Obstacle Reduction Shell
+	{
+		hit = 250;
+		indirectHit = 60;
+		indirectHitRange = 6;
+		warheadName = "HE";
+		dangerRadiusHit = 160;
+		suppressionRadiusHit = 32;
+		typicalSpeed = 1400;
+		explosive = 0.8;
+		cost = 300;
+		airFriction = -0.000275;
+		caliber = 10;
+		deflecting = 4;
+		timeToLive = 15;
+		whistleOnFire = 1;
+		whistleDist = 14;
+		model = "\A3\Weapons_f\Data\bullettracer\shell_tracer_red";
+		tracerScale = 1;
+		tracerStartTime = 0.1;
+		tracerEndTime = 3.0;
+		muzzleEffect = "";
+		soundHit1[] = {"A3\Sounds_F\arsenal\explosives\shells\Tank_shell_explosion_01",1.7782794,1,1800};
+		soundHit2[] = {"A3\Sounds_F\arsenal\explosives\shells\Tank_shell_explosion_02",1.7782794,1,1800};
+		soundHit3[] = {"A3\Sounds_F\arsenal\explosives\shells\Tank_shell_explosion_03",1.7782794,1,1800};
+		soundHit4[] = {"A3\Sounds_F\arsenal\explosives\shells\Tank_shell_explosion_04",1.7782794,1,1800};
+		multiSoundHit[] = {"soundHit1",0.25,"soundHit2",0.25,"soundHit3",0.25,"soundHit4",0.25};
+		class CamShakeExplode
+		{
+			power = 24;
+			duration = 2.2;
+			frequency = 20;
+			distance = 143.636;
+		};
+		class CamShakeHit
+		{
+			power = 120;
+			duration = 0.6;
+			frequency = 20;
+			distance = 1;
+		};
+		class CamShakeFire
+		{
+			power = 3.30975;
+			duration = 2.2;
+			frequency = 20;
+			distance = 87.6356;
+		};
+		class CamShakePlayerFire
+		{
+			power = 0.02;
+			duration = 0.1;
+			frequency = 20;
+			distance = 1;
+		};
+	};
+	class adfrc_abrams_120mm_M1028_C: Sh_120mm_HE ///Canister
+	{
+		Hit = 50;
+		indirectHit = 1;
+		indirectHitRange = 1;
+		caliber = 5;
+		warheadName = "HE";
+		dangerRadiusHit = 160;
+		suppressionRadiusHit = 32;
+		typicalSpeed = 1400;
+		explosive = 0.8;
+		cost = 300;
+		airFriction = -0.000275;
+		deflecting = 4;
+		timeToLive = 15;
+		whistleOnFire = 1;
+		whistleDist = 14;
+		model = "\A3\Weapons_f\Data\bullettracer\shell_tracer_white";
+		tracerScale = 1;
+		tracerStartTime = 0.1;
+		tracerEndTime = 3.0;
+		muzzleEffect = "";
+		soundHit1[] = {"A3\Sounds_F\arsenal\explosives\shells\Tank_shell_explosion_01",1.7782794,1,1800};
+		soundHit2[] = {"A3\Sounds_F\arsenal\explosives\shells\Tank_shell_explosion_02",1.7782794,1,1800};
+		soundHit3[] = {"A3\Sounds_F\arsenal\explosives\shells\Tank_shell_explosion_03",1.7782794,1,1800};
+		soundHit4[] = {"A3\Sounds_F\arsenal\explosives\shells\Tank_shell_explosion_04",1.7782794,1,1800};
+		multiSoundHit[] = {"soundHit1",0.25,"soundHit2",0.25,"soundHit3",0.25,"soundHit4",0.25};
+		class CamShakeExplode
+		{
+			power = 24;
+			duration = 2.2;
+			frequency = 20;
+			distance = 143.636;
+		};
+		class CamShakeHit
+		{
+			power = 120;
+			duration = 0.6;
+			frequency = 20;
+			distance = 1;
+		};
+		class CamShakeFire
+		{
+			power = 3.30975;
+			duration = 2.2;
+			frequency = 20;
+			distance = 87.6356;
+		};
+		class CamShakePlayerFire
+		{
+			power = 0.02;
+			duration = 0.1;
+			frequency = 20;
+			distance = 1;
+		};
+		submunitionAmmo = "adfrc_abrams_120mm_M1028_C_Deploy";
+		submunitionConeType[] =
+		{
+			"randomcenter",
+			100
+		};
+		submunitionConeAngle = 0.60;
+		triggerSpeedCoef[] = {0.85000002,1};
+		triggerTime = 0.001;
+	};
+	class adfrc_abrams_120mm_M1028_C_Deploy : B_12Gauge_Pellets_Submunition_Deploy ///Canister Pellets
+	{
+		airFriction = -0.0066999998;
+		hit = 25;
+		indirectHit = 2;
+		indirectHitRange = 1;
+		typicalSpeed = 1000;
+		deflecting = 45;
 	};
 };
 class cfgMagazines
 {
+	class VehicleMagazine;
 	class 150Rnd_762x51_Box;
-	class ADFRC_abrams_1000Rnd_762x51_Tracer: 150Rnd_762x51_Box {
-		scope = 1;
-		ammo = "ADFRC_abrams_762x51_Tracer";
-		displayName = "1000 Round 7.62mm Tracer";
-		displayNameShort = "Tracer";
-		descriptionShort = "$STR_A3_CfgMagazines_150Rnd_762x51_Box_Tracer1";
-		count = 1000;
-		type = "2*		256";
-		tracersEvery = 4;
-	};
-	class ADFRC_abrams_200rnd_762x51_Tracer: 150Rnd_762x51_Box{
-		scope = 1;
-		ammo = "ADFRC_abrams_762x51_Tracer";
-		displayName = "200 Round 7.62mm Tracer";
-		displayNameShort = "Tracer";
-		descriptionShort = "$STR_A3_CfgMagazines_150Rnd_762x51_Box_Tracer1";
+	class adfrc_abrams_200Rnd_762x51_Tracer: 150Rnd_762x51_Box 
+	{
+		scope = 2;
+		ammo = "B_762x54_Tracer_Red";
+		author = "Quiggs";
+		displayName = "200rnd 7.62 B";
+		displayNameShort = "M80A1 Ball";
+		descriptionShort = "$STR_A3_CfgMagazines_2000Rnd_762x45_Belt1";
 		count = 200;
 		type = "2*		256";
 		tracersEvery = 4;
 	};
-	class ADFRC_abrams_100rnd_762x51_Tracer: 150Rnd_762x51_Box{
-		scope = 1;
-		ammo = "ADFRC_abrams_762x51_Tracer";
-		displayName = "100 Round 7.62mm Tracer";
-		displayNameShort = "Tracer";
-		descriptionShort = "$STR_A3_CfgMagazines_150Rnd_762x51_Box_Tracer1";
-		count = 100;
-		type = "2*		256";
-		tracersEvery = 4;
-	};
-	class SmokeLauncherMag;
-    class ADFRC_SmokeLauncherMag: SmokeLauncherMag 
+	
+	//*
+    //* 120mm
+    //*
+	
+	class adfrc_abrams_1Rnd_M829A2_shell: VehicleMagazine
 	{
-        ammo = "ADFRC_SmokeLauncherAmmo";
-		count = 2;
-    };
+		author = "Quiggs";
+		scope = 2;
+		displayName = "M829A2 (APFSDS)";
+		displayNameShort = "APFSDS";
+		ammo = "adfrc_abrams_120mm_M829A2_APFSDS";
+		nameSound = "cannon";
+		initSpeed = 1680;
+		count = 1;
+		maxLeadSpeed = 25;
+		tracersEvery = 1;
+		muzzleImpulseFactor[] = { 10, 0.8 };
+	};
+	class adfrc_abrams_1Rnd_M830A1_shell: adfrc_abrams_1Rnd_M829A2_shell
+	{
+		author = "Quiggs";
+		scope = 2;
+		displayName = "M830A1 (HEAT-MP)";
+		displayNameShort = "HEAT-MP";
+		ammo = "adfrc_abrams_120mm_M830A1_HEATMP";
+		tracersEvery = 1;
+		initSpeed = 1410;
+	};
+	class adfrc_abrams_1Rnd_M908_shell: adfrc_abrams_1Rnd_M829A2_shell
+	{
+		author = "Quiggs";
+		scope = 2;
+		displayName = "M908 (HE-OR)";
+		displayNameShort = "HE-OR";
+		ammo = "adfrc_abrams_120mm_M908_HE";
+		tracersEvery = 1;
+		initSpeed = 1400;
+	};
+	class adfrc_abrams_1Rnd_M1028_shell: adfrc_abrams_1Rnd_M829A2_shell
+	{
+		author = "Quiggs";
+		scope = 2;
+		displayName = "M1028 (Canister)";
+		displayNameShort = "Canister";
+		ammo = "adfrc_abrams_120mm_M1028_C";
+		tracersEvery = 0;
+		initSpeed = 1410;
+	};
 };
-class Mode_SemiAuto;
-class Mode_Burst;
-class Mode_FullAuto;
-
 class cfgWeapons
 {
 	class MGun;
 	class HMG_M2_Mounted;
 	class LMG_coax_ext;
-	class ADFRC_abrams_coax: LMG_coax_ext
+	class adfrc_abrams_coax: LMG_coax_ext
 	{
-		displayName = "MG 7.62mm Mag 58 Coax";
+		displayName = "MG 7.62mm Mag58 Coax";
 		scope = 2;
+		canlock = 0;
+		airLock = 0;
+		ballisticsComputer = "2 + 16";
 		magazines[]=
 		{
-			"ADFRC_abrams_1000Rnd_762x51_Tracer",
 			"ADFRC_abrams_200Rnd_762x51_Tracer"
 		};
 		class GunParticles 
 		{
-
 			class effect1 
 			{
 				effectName = "MachineGunCloud";
@@ -131,13 +422,12 @@ class cfgWeapons
 	};	
 	class ADFRC_abrams_mag58: ADFRC_abrams_coax
 	{
-		displayName = "MG 7.62mm Mag 58";
+		displayName = "MG 7.62mm Mag58";
 		scope = 2;
+		ballisticsComputer = 2;
 		magazines[]=
 		{
-			"ADFRC_abrams_1000Rnd_762x51_Tracer",
-			"ADFRC_abrams_200Rnd_762x51_Tracer",
-			"ADFRC_abrams_100Rnd_762x51_Tracer"
+			"ADFRC_abrams_200Rnd_762x51_Tracer"
 		};
 		class GunParticles 
 		{
@@ -151,7 +441,7 @@ class cfgWeapons
 	};
 	class player;
 	class cannon_120mm;
-	class ADFRC_abrams_M256: cannon_120mm
+	class adfrc_abrams_M256: cannon_120mm
 	{
 		displayName = "M256 120mm Cannon";
 		scope = 2;
@@ -164,6 +454,13 @@ class cfgWeapons
 		magazineReloadTime = 6;
 		//reloadSound[]={"ADF_Tracked\adfrc_abrams\sounds\weapons\shells\adfrc_abrams_reload.wss",100,100};
 		reloadTime = 6;
+		magazines[]=
+		{
+			"adfrc_abrams_1Rnd_M829A2_shell",
+			"adfrc_abrams_1Rnd_M830A1_shell",
+			"adfrc_abrams_1Rnd_M908_shell",
+			"adfrc_abrams_1Rnd_M1028_shell",
+		};
 		class GunParticles 
 		{
 			class effect1
@@ -174,7 +471,7 @@ class cfgWeapons
 			};
 		};
 	};
-	class ADFRC_abrams_M2HBQCB: HMG_M2_Mounted 
+	class adfrc_abrams_M2HBQCB: HMG_M2_Mounted 
 	{
 		displayName="12.7mm M2HB QCB MG";
 		scope = 2;
@@ -200,7 +497,7 @@ class cfgWeapons
 			};
 		};
 	};
-	class ADFRC_abrams_M2HBQCB_RWS: ADFRC_abrams_M2HBQCB 
+	class adfrc_abrams_M2HBQCB_RWS: ADFRC_abrams_M2HBQCB 
 	{
 		displayName="Kongsberg RS4LP - M2HB MG";
 		scope = 2;

--- a/Addons/ADF_Tracked/adfrc_abrams/config.cpp
+++ b/Addons/ADF_Tracked/adfrc_abrams/config.cpp
@@ -600,16 +600,16 @@ class CfgVehicles
 						};
 						magazines[]=
 						{
-							"200rnd_127x99_mag_Tracer_Red",
-							"200rnd_127x99_mag_Tracer_Red",
-							"200rnd_127x99_mag_Tracer_Red",
-							"200rnd_127x99_mag_Tracer_Red",
-							"200rnd_127x99_mag_Tracer_Red",
-							"200rnd_127x99_mag_Tracer_Red",
-							"200rnd_127x99_mag_Tracer_Red",
-							"200rnd_127x99_mag_Tracer_Red",
-							"200rnd_127x99_mag_Tracer_Red",
-							"200rnd_127x99_mag_Tracer_Red",
+							"100rnd_127x99_mag_Tracer_Red",
+							"100rnd_127x99_mag_Tracer_Red",
+							"100rnd_127x99_mag_Tracer_Red",
+							"100rnd_127x99_mag_Tracer_Red",
+							"100rnd_127x99_mag_Tracer_Red",
+							"100rnd_127x99_mag_Tracer_Red",
+							"100rnd_127x99_mag_Tracer_Red",
+							"100rnd_127x99_mag_Tracer_Red",
+							"100rnd_127x99_mag_Tracer_Red",
+							"100rnd_127x99_mag_Tracer_Red",
 							"SmokeLauncherMag"
 						};
 						soundServo[]=

--- a/Addons/ADF_Tracked/adfrc_abrams/config.cpp
+++ b/Addons/ADF_Tracked/adfrc_abrams/config.cpp
@@ -15,7 +15,9 @@ class CfgPatches
 		units[]=
 		{
 			"adfrc_abrams",
-			"adfrc_m1a1aim"
+			"adfrc_m1a1aim_md",
+			"adfrc_m1a1aim_gwot",
+			"adfrc_m1a2sepv3_md",
 		};
 		weapons[]=
 		{
@@ -27,9 +29,12 @@ class CfgPatches
 		};
 		magazines[]=
 		{
-			"ADFRC_abrams_1000Rnd_762x51_Tracer",
-			"ADFRC_abrams_200Rnd_762x51_Tracer",
-			"ADFRC_abrams_100rnd_762x51_Tracer",
+			"adfrc_abrams_1000Rnd_762x51_Tracer",
+			"adfrc_abrams_200Rnd_762x51_Tracer",
+			"adfrc_abrams_1Rnd_M829A2_shell",
+			"adfrc_abrams_1Rnd_M830A1_shell",
+			"adfrc_abrams_1Rnd_M908_shell",
+			"adfrc_abrams_1Rnd_M1028_shell",
 		};
 	};
 };
@@ -398,21 +403,21 @@ class CfgVehicles
 		};
 		class ViewPilot: ViewPilot
 		{
-			initAngleX=-3;
+			initAngleX=0;
 			initAngleY=0;
-			initFov=0.89999998;
+			initFov=0.95;
 			minFov=0.25;
 			maxFov=1.25;
 			minAngleX=-65;
 			maxAngleX=85;
 			minAngleY=-150;
 			maxAngleY=150;
-			minMoveX=-0.01;
-			maxMoveX=0.01;
-			minMoveY=-0.01;
-			maxMoveY=0.01;
-			minMoveZ=-0.01;
-			maxMoveZ=0.01;
+			minMoveX=-0.075;
+			maxMoveX=0.075;
+			minMoveY=-0.075;
+			maxMoveY=0.015;
+			minMoveZ=-0.075;
+			maxMoveZ=0.075;
 		};
 		class Reflectors
 		{
@@ -595,16 +600,16 @@ class CfgVehicles
 						};
 						magazines[]=
 						{
-							"100Rnd_127x99_mag_Tracer_Red",
-							"100Rnd_127x99_mag_Tracer_Red",
-							"100Rnd_127x99_mag_Tracer_Red",
-							"100Rnd_127x99_mag_Tracer_Red",
-							"100Rnd_127x99_mag_Tracer_Red",
-							"100Rnd_127x99_mag_Tracer_Red",
-							"100Rnd_127x99_mag_Tracer_Red",
-							"100Rnd_127x99_mag_Tracer_Red",
-							"100Rnd_127x99_mag_Tracer_Red",
-							"100Rnd_127x99_mag_Tracer_Red",
+							"200rnd_127x99_mag_Tracer_Red",
+							"200rnd_127x99_mag_Tracer_Red",
+							"200rnd_127x99_mag_Tracer_Red",
+							"200rnd_127x99_mag_Tracer_Red",
+							"200rnd_127x99_mag_Tracer_Red",
+							"200rnd_127x99_mag_Tracer_Red",
+							"200rnd_127x99_mag_Tracer_Red",
+							"200rnd_127x99_mag_Tracer_Red",
+							"200rnd_127x99_mag_Tracer_Red",
+							"200rnd_127x99_mag_Tracer_Red",
 							"SmokeLauncherMag"
 						};
 						soundServo[]=
@@ -832,9 +837,48 @@ class CfgVehicles
 				};
 				magazines[]=
 				{
-					"20Rnd_120mm_APFSDS_shells_Tracer_Red",
-					"12Rnd_120mm_HE_shells_Tracer_Red",
-					"12Rnd_120mm_HEAT_MP_T_Red",
+					"adfrc_abrams_1Rnd_M829A2_shell",
+					"adfrc_abrams_1Rnd_M829A2_shell",
+					"adfrc_abrams_1Rnd_M829A2_shell",
+					"adfrc_abrams_1Rnd_M829A2_shell",
+					"adfrc_abrams_1Rnd_M829A2_shell",
+					"adfrc_abrams_1Rnd_M829A2_shell",
+					"adfrc_abrams_1Rnd_M829A2_shell",
+					"adfrc_abrams_1Rnd_M829A2_shell",
+					"adfrc_abrams_1Rnd_M829A2_shell",
+					"adfrc_abrams_1Rnd_M829A2_shell",
+					"adfrc_abrams_1Rnd_M829A2_shell",
+					"adfrc_abrams_1Rnd_M829A2_shell",
+					"adfrc_abrams_1Rnd_M829A2_shell",
+					"adfrc_abrams_1Rnd_M829A2_shell",
+					"adfrc_abrams_1Rnd_M829A2_shell",
+					"adfrc_abrams_1Rnd_M829A2_shell",
+					"adfrc_abrams_1Rnd_M829A2_shell",
+					"adfrc_abrams_1Rnd_M829A2_shell",
+					"adfrc_abrams_1Rnd_M829A2_shell",
+					"adfrc_abrams_1Rnd_M829A2_shell",
+					"adfrc_abrams_1Rnd_M830A1_shell",
+					"adfrc_abrams_1Rnd_M830A1_shell",
+					"adfrc_abrams_1Rnd_M830A1_shell",
+					"adfrc_abrams_1Rnd_M830A1_shell",
+					"adfrc_abrams_1Rnd_M830A1_shell",
+					"adfrc_abrams_1Rnd_M830A1_shell",
+					"adfrc_abrams_1Rnd_M830A1_shell",
+					"adfrc_abrams_1Rnd_M830A1_shell",
+					"adfrc_abrams_1Rnd_M830A1_shell",
+					"adfrc_abrams_1Rnd_M830A1_shell",
+					"adfrc_abrams_1Rnd_M908_shell",
+					"adfrc_abrams_1Rnd_M908_shell",
+					"adfrc_abrams_1Rnd_M908_shell",
+					"adfrc_abrams_1Rnd_M908_shell",
+					"adfrc_abrams_1Rnd_M908_shell",
+					"adfrc_abrams_1Rnd_M908_shell",
+					"adfrc_abrams_1Rnd_M908_shell",
+					"adfrc_abrams_1Rnd_M1028_shell",
+					"adfrc_abrams_1Rnd_M1028_shell",
+					"adfrc_abrams_1Rnd_M1028_shell",
+					"adfrc_abrams_1Rnd_M1028_shell",
+					"adfrc_abrams_1Rnd_M1028_shell",
 					"ADFRC_abrams_200Rnd_762x51_Tracer",
 					"ADFRC_abrams_200Rnd_762x51_Tracer",
 					"ADFRC_abrams_200Rnd_762x51_Tracer",
@@ -850,7 +894,7 @@ class CfgVehicles
 					"ADFRC_abrams_200Rnd_762x51_Tracer",
 					"ADFRC_abrams_200Rnd_762x51_Tracer",
 					"ADFRC_abrams_200Rnd_762x51_Tracer",
-					"ADFRC_abrams_200Rnd_762x51_Tracer"
+					"ADFRC_abrams_200Rnd_762x51_Tracer",
 				};
 				soundServo[]=
 				{
@@ -1089,19 +1133,19 @@ class CfgVehicles
 				magazines[]=
 				{
 					
-					"ADFRC_abrams_100rnd_762x51_Tracer",
-					"ADFRC_abrams_100rnd_762x51_Tracer",
-					"ADFRC_abrams_100rnd_762x51_Tracer",
-					"ADFRC_abrams_100rnd_762x51_Tracer",
-					"ADFRC_abrams_100rnd_762x51_Tracer",
-					"ADFRC_abrams_100rnd_762x51_Tracer",
-					"ADFRC_abrams_100rnd_762x51_Tracer",
-					"ADFRC_abrams_100rnd_762x51_Tracer",
-					"ADFRC_abrams_100rnd_762x51_Tracer",
-					"ADFRC_abrams_100rnd_762x51_Tracer",
-					"ADFRC_abrams_100rnd_762x51_Tracer",
-					"ADFRC_abrams_100rnd_762x51_Tracer",
-					"ADFRC_abrams_100rnd_762x51_Tracer"
+					"ADFRC_abrams_200rnd_762x51_Tracer",
+					"ADFRC_abrams_200rnd_762x51_Tracer",
+					"ADFRC_abrams_200rnd_762x51_Tracer",
+					"ADFRC_abrams_200rnd_762x51_Tracer",
+					"ADFRC_abrams_200rnd_762x51_Tracer",
+					"ADFRC_abrams_200rnd_762x51_Tracer",
+					"ADFRC_abrams_200rnd_762x51_Tracer",
+					"ADFRC_abrams_200rnd_762x51_Tracer",
+					"ADFRC_abrams_200rnd_762x51_Tracer",
+					"ADFRC_abrams_200rnd_762x51_Tracer",
+					"ADFRC_abrams_200rnd_762x51_Tracer",
+					"ADFRC_abrams_200rnd_762x51_Tracer",
+					"ADFRC_abrams_200rnd_762x51_Tracer"
 				};
 				soundServo[]=
 				{
@@ -3097,16 +3141,16 @@ class CfgVehicles
 						};
 						magazines[]=
 						{
-							"100Rnd_127x99_mag_Tracer_Red",
-							"100Rnd_127x99_mag_Tracer_Red",
-							"100Rnd_127x99_mag_Tracer_Red",
-							"100Rnd_127x99_mag_Tracer_Red",
-							"100Rnd_127x99_mag_Tracer_Red",
-							"100Rnd_127x99_mag_Tracer_Red",
-							"100Rnd_127x99_mag_Tracer_Red",
-							"100Rnd_127x99_mag_Tracer_Red",
-							"100Rnd_127x99_mag_Tracer_Red",
-							"100Rnd_127x99_mag_Tracer_Red",
+							"100rnd_127x99_mag_Tracer_Red",
+							"100rnd_127x99_mag_Tracer_Red",
+							"100rnd_127x99_mag_Tracer_Red",
+							"100rnd_127x99_mag_Tracer_Red",
+							"100rnd_127x99_mag_Tracer_Red",
+							"100rnd_127x99_mag_Tracer_Red",
+							"100rnd_127x99_mag_Tracer_Red",
+							"100rnd_127x99_mag_Tracer_Red",
+							"100rnd_127x99_mag_Tracer_Red",
+							"100rnd_127x99_mag_Tracer_Red",
 							"Laserbatteries",
 							"SmokeLauncherMag"
 						};


### PR DESCRIPTION
### Model & Config updates for the Abrams.

**Config changes:**
- **Added custom M256 ammo**, 
   - _M829A2, M830A, M908 & M1028_
   - _42 rounds total, 20 APFSDS, 10 HEAT-MP, 7 HE-OR, 5 Canister_ is the Default loadout.
   - Benefits to this is operators can manually select how many rounds they want to bring.
- Updated Mag58 ammo to only have 200rnd magazines for coax & pintle
- Updated `class ViewPilot` for the driver, giving more head adjustments for keyboard users
- Fixed Mag58 not having a ballistic computer & removed laser range finder for loaders Mag58
- General config cleanup

**Model changes:**
- Fixed LXRF bag error, replaced with rolled sleeping bag (fixs big white square appearing)
- Fixed inverted faces on the plows power cable
- Fixed pilot lod plow having incorrect UV layout (M1A1) & missing the turret & garage selections (M1A1 & M1A2)
- Adjusted pilot lod proxy
- Optimized cargo & pilot lods removing unseen geometry

_**Note:**_ 
Mag58 & M2HB belt animation issues still persist, not yet finished remaking.
Until a script is made, there is technically no limit to how many rounds can be stored in the Abrams, & you cannot see how many individual rounds are left, only overall.
@IsoBones an SQF script may be needed, I know RHS & CUP have one so may be something simple to look at. 