### PR TITLE
Add plow functionality abrams

### DIFF
--- a/.github/workflows/sqflint.yml
+++ b/.github/workflows/sqflint.yml
@@ -6,9 +6,11 @@ on:
     paths:
       - 'Addons/**/*.sqf'
       - '.github/workflows/sqflint.yml'
+      - 'tools/sqf_lint.py'
   pull_request:
     paths:
       - 'Addons/**/*.sqf'
+      - 'tools/sqf_lint.py'
 
 jobs:
   sqflint:
@@ -19,11 +21,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-          sparse-checkout: |
-            Addons
-          sparse-checkout-cone-mode: true
 
-      - name: Run SQFLint
-        uses: arma-actions/sqflint@master
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          args: --exit e --directory Addons
+          python-version: '3.11'
+
+      # The linter is a single stdlib-only Python script. No pip install,
+      # no docker, no rust toolchain.
+      #
+      # Errors fail the job. Warnings don't (drop --no-warnings if you want
+      # them visible in CI). Once existing warnings are cleaned up, swap
+      # --no-warnings for -W to also block on warnings.
+      - name: Run sqf_lint
+        run: python3 tools/sqf_lint.py Addons --no-warnings

--- a/Addons/ADF_Core/cbaSettings.hpp
+++ b/Addons/ADF_Core/cbaSettings.hpp
@@ -1,0 +1,7 @@
+class Extended_PreInit_EventHandlers
+{
+    class ADF_Core
+    {
+        init = "call compile preprocessFileLineNumbers '\ADF_Core\scripts\initSettings.sqf'";
+    };
+};

--- a/Addons/ADF_Core/config.cpp
+++ b/Addons/ADF_Core/config.cpp
@@ -2,7 +2,7 @@ class CfgPatches
 {
 	class ADF_Core
 	{
-		requiredAddons[] = {"A3_Data_F","cba_jr"};
+		requiredAddons[] = {"A3_Data_F","cba_jr","cba_settings"};
 		requiredVersion = 0.1;
 		units[] = {};
 		weapons[] = {};
@@ -19,3 +19,4 @@ class CfgPatches
 #include "cfgVehicleClasses.hpp"
 #include "cfgVehicles.hpp"
 #include "sensors.hpp"
+#include "cbaSettings.hpp"

--- a/Addons/ADF_Core/scripts/initSettings.sqf
+++ b/Addons/ADF_Core/scripts/initSettings.sqf
@@ -1,0 +1,18 @@
+// CBA mod-wide settings for ADF Re-Cut.
+// Uses CBA_fnc_addSetting (safe to call from preInit without cba_settings as a hard dependency).
+
+[
+    "ADFRC_plow_clearMines",
+    "CHECKBOX",
+    ["Mine plow clears mines", "When enabled, lowered mine plows automatically destroy mines they encounter without damaging the vehicle. Plow must be fully deployed."],
+    "ADF Re-Cut",
+    true
+] call CBA_fnc_addSetting;
+
+[
+    "ADFRC_plow_digTrenches",
+    "CHECKBOX",
+    ["Mine plow digs trenches", "When enabled and grad_trenches is loaded, lowered mine plows can dig vehicle trenches by driving forward. No effect without grad_trenches."],
+    "ADF Re-Cut",
+    true
+] call CBA_fnc_addSetting;

--- a/Addons/ADF_Core/stringtable.xml
+++ b/Addons/ADF_Core/stringtable.xml
@@ -75,5 +75,27 @@
 					<English>F1 Fragmentation Grenade</English>
 			</Key>
 		</Container>
+		<Container name="Settings">
+			<Key ID="STR_ADFRC_settingsCategory">
+				<Original>ADF Re-Cut</Original>
+				<English>ADF Re-Cut</English>
+			</Key>
+			<Key ID="STR_ADFRC_plowClearMines_name">
+				<Original>Mine plow clears mines</Original>
+				<English>Mine plow clears mines</English>
+			</Key>
+			<Key ID="STR_ADFRC_plowClearMines_tooltip">
+				<Original>When enabled, lowered mine plows automatically destroy mines they encounter without damaging the vehicle. Plow must be fully deployed.</Original>
+				<English>When enabled, lowered mine plows automatically destroy mines they encounter without damaging the vehicle. Plow must be fully deployed.</English>
+			</Key>
+			<Key ID="STR_ADFRC_plowDigTrenches_name">
+				<Original>Mine plow digs trenches</Original>
+				<English>Mine plow digs trenches</English>
+			</Key>
+			<Key ID="STR_ADFRC_plowDigTrenches_tooltip">
+				<Original>When enabled and grad_trenches is loaded, lowered mine plows can dig vehicle trenches by driving forward. No effect without grad_trenches.</Original>
+				<English>When enabled and grad_trenches is loaded, lowered mine plows can dig vehicle trenches by driving forward. No effect without grad_trenches.</English>
+			</Key>
+		</Container>
 	</Package>
 </Project>

--- a/Addons/ADF_Tracked/adfrc_abrams/CfgDigVehicles.hpp
+++ b/Addons/ADF_Tracked/adfrc_abrams/CfgDigVehicles.hpp
@@ -1,0 +1,16 @@
+// grad_trenches addition, only matters when that mod is loaded
+class CfgDigVehicles
+{
+    class adfrc_abrams
+    {
+        type = "animate";              // 'plow' is a door anim, 'animate' command works on doors
+        animation = "plow";            // matches the AnimationSource 'plow' (source="door")
+        selection = "plow";            // for the digging particle FX position
+        plowRaised = 0;
+        plowLowered = 1;               // door anim goes 0->1 (rad 20 in model.cfg)
+        distanceToTrench = 4.5;        // tune this - distance forward from vehicle origin to trench
+    };
+    class adfrc_m1a1aim_md:    adfrc_abrams {};
+    class adfrc_m1a1aim_gwot:  adfrc_abrams {};
+    class adfrc_m1a2sepv3_md:  adfrc_abrams {};
+};

--- a/Addons/ADF_Tracked/adfrc_abrams/config.cpp
+++ b/Addons/ADF_Tracked/adfrc_abrams/config.cpp
@@ -10,6 +10,7 @@ class CfgPatches
 			"ADF_Tracked",
 			"ADF_Weapons",
 			"A3_Armor_F_EPB",
+			"cba_main",
 		};
 		requiredVersion=0.1;
 		units[]=
@@ -40,6 +41,7 @@ class CfgPatches
 };
 
 #include "c_ammo.hpp"
+#include "CfgDigVehicles.hpp"
 class DefaultEventHandlers;
 class WeaponFireGun;
 class WeaponCloudsGun;
@@ -2309,28 +2311,6 @@ class CfgVehicles
 			"sprocketcovers",
 			1,
 		};
-		class UserActions
-        {
-            class lower_plow
-            {
-                userActionID=50;
-                displayName="Lower plow";
-                radius=10;
-                showIn3D=17;
-                priority=1;
-                position="gunnerview";
-                onlyForPlayer=0;
-                condition="(alive this) && (isengineon this) && (this animationsourcephase 'plow' == 0) && (player in this) && (this animationsourcephase 'hideplow' == 1)";
-                statement="this animateDoor ['plow', 1];";
-            };
-            class raise_plow: lower_plow
-            {
-                userActionID=51;
-                displayName="Raise plow";
-                condition="(alive this) && (isengineon this) && (this animationsourcephase 'plow' == 1) && (player in this) && (this animationsourcephase 'hideplow' == 1)";
-                statement="this animateDoor [""plow"", 0];";
-            };
-        };
 		hiddenSelections[]=
 		{
 			"abramshull1",
@@ -3538,4 +3518,14 @@ class CfgVehicles
 			};
 		};
 	};
+};
+class Extended_Init_EventHandlers
+{
+    class adfrc_abrams
+    {
+        ADFRC_plowInit = "_this call compile preprocessFileLineNumbers '\ADF_Tracked\adfrc_abrams\scripts\fn_plowInit.sqf'";
+    };
+    class adfrc_m1a1aim_md:    adfrc_abrams {};
+    class adfrc_m1a1aim_gwot:  adfrc_abrams {};
+    class adfrc_m1a2sepv3_md:  adfrc_abrams {};
 };

--- a/Addons/ADF_Tracked/adfrc_abrams/scripts/fn_plowInit.sqf
+++ b/Addons/ADF_Tracked/adfrc_abrams/scripts/fn_plowInit.sqf
@@ -1,0 +1,90 @@
+// Plow control with grad_trenches soft dependency.
+// Gated by CBA settings: ADFRC_plow_clearMines and ADFRC_plow_digTrenches.
+
+params ["_vehicle"];
+
+if (_vehicle getVariable ["adfrc_plowInitDone", false]) exitWith {};
+_vehicle setVariable ["adfrc_plowInitDone", true];
+
+if (isServer) then {
+    [{
+        params ["_args", "_handle"];
+        _args params ["_vehicle"];
+
+        if (isNull _vehicle || !alive _vehicle) exitWith {
+            [_handle] call CBA_fnc_removePerFrameHandler;
+        };
+
+        if !(missionNamespace getVariable ["ADFRC_plow_clearMines", true]) exitWith {};
+        if ((_vehicle animationPhase "plow") < 0.95) exitWith {};
+
+        private _searchPos = _vehicle modelToWorld [0, 6, 0];
+        private _mines = nearestObjects [_searchPos, ["MineBase"], 4];
+        { deleteVehicle _x; } forEach _mines;
+
+    }, 0.1, [_vehicle]] call CBA_fnc_addPerFrameHandler;
+};
+
+
+if (!hasInterface) exitWith {};
+[{
+    params ["_vehicle"];
+
+    for "_i" from 50 to 0 step -1 do {
+        private _params = _vehicle actionParams _i;
+        if (count _params > 0 && {(_params select 0) in ["Lower Plow", "Raise Plow"]}) then {
+            _vehicle removeAction _i;
+        };
+    };
+
+    private _baseCond = "alive _target && {isEngineOn _target} && {(_target animationSourcePhase 'hideplow') == 1} && {_this == driver _target}";
+
+    _vehicle addAction [
+        "Lower plow",
+        {
+            params ["_target"];
+            _target animateDoor ["plow", 1];
+
+            if (
+                (missionNamespace getVariable ["ADFRC_plow_digTrenches", true])
+                && {isClass (configFile >> "CfgPatches" >> "grad_trenches_functions")}
+            ) then {
+                _target setCruiseControl [7, false];
+                _target setVariable ["grad_trenches_functions_plowlowered", -1, true];
+                [
+                    { (_this animationPhase "plow") >= 0.99 },
+                    { _this setVariable ["grad_trenches_functions_plowlowered", 1, true] },
+                    _target
+                ] call CBA_fnc_waitUntilAndExecute;
+            };
+        },
+        nil, 1.5, true, true, "",
+        format ["%1 && {(_target animationPhase 'plow') < 0.5}", _baseCond],
+        10, false, "", ""
+    ];
+
+    _vehicle addAction [
+        "Raise plow",
+        {
+            params ["_target"];
+            _target animateDoor ["plow", 0];
+
+            if (
+                (missionNamespace getVariable ["ADFRC_plow_digTrenches", true])
+                && {isClass (configFile >> "CfgPatches" >> "grad_trenches_functions")}
+            ) then {
+                _target setCruiseControl [0, false];
+                _target setVariable ["grad_trenches_functions_plowlowered", -1, true];
+                [
+                    { (_this animationPhase "plow") <= 0.01 },
+                    { _this setVariable ["grad_trenches_functions_plowlowered", 0, true] },
+                    _target
+                ] call CBA_fnc_waitUntilAndExecute;
+            };
+        },
+        nil, 1.5, true, true, "",
+        format ["%1 && {(_target animationPhase 'plow') >= 0.5}", _baseCond],
+        10, false, "", ""
+    ];
+
+}, [_vehicle], 0.25] call CBA_fnc_waitAndExecute;


### PR DESCRIPTION
### The Motherlode!
This PR adds two functions to the new M1A1/M1A2 Abrams models alongside setup for CBA addon settings (with ability to expand our settings later if needed)

- Adds ability for mine plow to 'dig' vehicle trenches when [Gruppe Adler Trenches](https://steamcommunity.com/sharedfiles/filedetails/?id=1224892496&searchtext=adler) is loaded - this is a soft-dependency and will have no effect if grad_trenches is not loaded
- Adds ability for mine plow to remove mines immediately in front of the plow whilst travelling, but only if the mine is within the footprint of the plow (i.e. reversing over a mine will still damage the tank)
- Adds CBA addon settings to disable either of these abilities, with enforcement server-side or mission side, or no enforcement (client decides, not recommended)
- ADF_Core ground work established for further CBA addon settings if required in future by other areas of the mod

As an aside, the script used for the Abrams may be useful for other vehicles that will have a mine-plow attachment in future, or other mods that may want to use it for their own plows (looking at you RHS strykers!)