### PR TITLE
Chinook improvements.

### DIFF
--- a/Addons/ADF_Air/adfrc_chinook/config.cpp
+++ b/Addons/ADF_Air/adfrc_chinook/config.cpp
@@ -5797,7 +5797,7 @@ class CfgVehicles
 	class ADFRC_chinook_PCW: ADFRC_chinook
 	{
 		faction = "ADFRC_F_PCW";
-		scope=1
+		scope=1;
 	};
 	class ADFRC_chinook_VIV: ADFRC_chinook
 	{
@@ -5882,7 +5882,7 @@ class CfgVehicles
 	class ADFRC_chinook_VIV_PCW: ADFRC_chinook_VIV
 	{
 		faction = "ADFRC_F_PCW";
-		scope=1
+		scope=1;
 	};
 };
 class CfgAmmo

--- a/Addons/ADF_Air/adfrc_chinook/config.cpp
+++ b/Addons/ADF_Air/adfrc_chinook/config.cpp
@@ -5797,6 +5797,7 @@ class CfgVehicles
 	class ADFRC_chinook_PCW: ADFRC_chinook
 	{
 		faction = "ADFRC_F_PCW";
+		scope=1
 	};
 	class ADFRC_chinook_VIV: ADFRC_chinook
 	{
@@ -5881,6 +5882,7 @@ class CfgVehicles
 	class ADFRC_chinook_VIV_PCW: ADFRC_chinook_VIV
 	{
 		faction = "ADFRC_F_PCW";
+		scope=1
 	};
 };
 class CfgAmmo

--- a/Addons/ADF_Air/adfrc_chinook/config.cpp
+++ b/Addons/ADF_Air/adfrc_chinook/config.cpp
@@ -4526,13 +4526,42 @@ class CfgVehicles
 		{
 			"Camo1",
 			"Camo2",
-			"Camo3"
+			"Camo3",
+			"Camo4",
 		};
 		hiddenSelectionsTextures[]=
 		{
-			"ADF_Air\adfrc_chinook\data\ch47_ext_1_co.paa",
-			"ADF_Air\adfrc_chinook\data\ch47_ext_2_co.paa",
-			"ADF_Air\adfrc_chinook\data\ch47f_nalepky_ca.paa"
+			"ADF_Air\adfrc_chinook\data\ch47_ext_1_sand_co.paa",
+			"ADF_Air\adfrc_chinook\data\ch47_ext_2_sand_co.paa",
+			"ADF_Air\adfrc_chinook\data\ch47f_nalepky_ca.paa",
+			"ADF_Air\adfrc_chinook\data\ch47extras_sand_co.paa",
+		};
+		class TextureSources
+		{
+			class Black
+			{
+				displayName="Black";
+				author="ADFRC_Quiggs";
+				textures[]=
+				{
+					"ADF_Air\adfrc_chinook\data\ch47_ext_1_co.paa",
+					"ADF_Air\adfrc_chinook\data\ch47_ext_2_co.paa",
+					"ADF_Air\adfrc_chinook\data\ch47f_nalepky_ca.paa",
+					"ADF_Air\adfrc_chinook\data\ch47extras_co.paa",
+				};
+			};
+			class Sand
+			{
+				displayName="Sand";
+				author="ADFRC_Quiggs";
+				textures[]=
+				{
+					"ADF_Air\adfrc_chinook\data\ch47_ext_1_sand_co.paa",
+					"ADF_Air\adfrc_chinook\data\ch47_ext_2_sand_co.paa",
+					"ADF_Air\adfrc_chinook\data\ch47f_nalepky_ca.paa",
+					"ADF_Air\adfrc_chinook\data\ch47extras_sand_co.paa",
+				};
+			};
 		};
 		soundGetIn[]=
 		{
@@ -5748,6 +5777,22 @@ class CfgVehicles
 	class ADFRC_chinook_GWOT: ADFRC_chinook
 	{
 		faction = "ADFRC_F_GWOT";
+		author="$STR_ADF_AUTHOR";
+		displayname="CH-47D Chinook";
+		hiddenSelections[]=
+		{
+			"Camo1",
+			"Camo2",
+			"Camo3",
+			"Camo4",
+		};
+		hiddenSelectionsTextures[]=
+		{
+			"ADF_Air\adfrc_chinook\data\ch47_ext_1_co.paa",
+			"ADF_Air\adfrc_chinook\data\ch47_ext_2_co.paa",
+			"ADF_Air\adfrc_chinook\data\ch47f_nalepky_ca.paa",
+			"ADF_Air\adfrc_chinook\data\ch47extras_co.paa",
+		};
 	};
 	class ADFRC_chinook_PCW: ADFRC_chinook
 	{
@@ -5757,7 +5802,7 @@ class CfgVehicles
 	{
 		scope=2;
 		side=1;
-		author="Quiggs / Index";
+		author="$STR_ADF_AUTHOR";
 		faction = "ADFRC_F_MD";
 		model="ADF_Air\adfrc_chinook\CH_47F.P3D";
 		displayname="CH-47F Chinook (Cargo)";
@@ -5816,6 +5861,22 @@ class CfgVehicles
 	class ADFRC_chinook_VIV_GWOT: ADFRC_chinook_VIV
 	{
 		faction = "ADFRC_F_GWOT";
+		displayname="CH-47D Chinook (Cargo)";
+		author="$STR_ADF_AUTHOR";
+		hiddenSelections[]=
+		{
+			"Camo1",
+			"Camo2",
+			"Camo3",
+			"Camo4",
+		};
+		hiddenSelectionsTextures[]=
+		{
+			"ADF_Air\adfrc_chinook\data\ch47_ext_1_co.paa",
+			"ADF_Air\adfrc_chinook\data\ch47_ext_2_co.paa",
+			"ADF_Air\adfrc_chinook\data\ch47f_nalepky_ca.paa",
+			"ADF_Air\adfrc_chinook\data\ch47extras_co.paa",
+		};
 	};
 	class ADFRC_chinook_VIV_PCW: ADFRC_chinook_VIV
 	{

--- a/Addons/ADF_Air/adfrc_chinook/data/ch47_ext_1_sand_co.paa
+++ b/Addons/ADF_Air/adfrc_chinook/data/ch47_ext_1_sand_co.paa
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7eabdf50d2510b72295a36cbb484c46dd1517074061d71e1e602d76aef7b60d
+size 1623314

--- a/Addons/ADF_Air/adfrc_chinook/data/ch47_ext_2_sand_co.paa
+++ b/Addons/ADF_Air/adfrc_chinook/data/ch47_ext_2_sand_co.paa
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d5d3572f3c6386df37b66eb7fb38ea7f1ccf202fad893c071a8259e53c95821
+size 1465234

--- a/Addons/ADF_Air/adfrc_chinook/data/ch47extras_sand_co.paa
+++ b/Addons/ADF_Air/adfrc_chinook/data/ch47extras_sand_co.paa
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7966a31790428f169dadff6e25cff20293bf33ca21967da6e7dba01b1e35db23
+size 372611

--- a/Addons/ADF_Air/adfrc_chinook/model.cfg
+++ b/Addons/ADF_Air/adfrc_chinook/model.cfg
@@ -489,7 +489,8 @@ class CfgModels
 			"zasleh_1",
 			"camo1",
 			"camo2",
-			"camo3"
+			"camo3",
+			"camo4",
 		};
 		skeletonName = "CH_47F_Skeleton";
 		class Animations


### PR DESCRIPTION
### Chinook improvements.
<img width="5120" height="1440" alt="20EA0A~1" src="https://github.com/user-attachments/assets/fd170e54-7fa5-4721-821d-8ffaedae30bc" />

- Added "Sand" camo
  - MD spawn with sand camo by default
  - GWOT spawn with black camo by default
  - All versions can have the camo selected in the garage
- Fixed not flying when spawned in air
   - This was done by removing the roadway lod, downside to this is you can no longer walk inside it
- Fixed all versions showing "Unknown Community Author"
- Changed GWOT to show "D" (1995–2010s) versions, MD shows "F" (2014–Present)

Closes #194 Closes #207 

@IsoBones Ill leave it to you to amend the PCW config stuff since thats being removed, dunno what you wanted to do with that.