### PR TITLE
Gustaf Ammo trajectory fix

### DIFF
--- a/Addons/ADF_Weapons/adfrc_carlgustav/config.cpp
+++ b/Addons/ADF_Weapons/adfrc_carlgustav/config.cpp
@@ -81,7 +81,7 @@ class cfgAmmo
 		indirectHitRange=20;
 		cost=200;
 		airFriction=0.075000003;
-		sideAirFriction=0.075000003;
+		sideAirFriction=0;
 		maxSpeed=265;
 		initTime=0;
 		thrustTime=0;


### PR DESCRIPTION
Fixed Gustaf rounds, especially the 551C [Rocket-Powered] round by changing the `sideAirFriction` to `0`, this was causing the round to go off course massively, round will now fly straight as it is intended to do so. Mods that add ammo ballistics such as ACE will still affect the ammo which is intended. However if in the future guided rounds are being added `sideAirFriction`  needs to be set under the guided round class otherwise it will not turn.
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/7ce72145-dfa3-4505-bc67-afd58a975cce" />
