### PR TITLE
Add plow states, mine clearing and actions

### DIFF
--- a/Addons/ADF_Tracked/adfrc_abrams/scripts/fn_plowInit.sqf
+++ b/Addons/ADF_Tracked/adfrc_abrams/scripts/fn_plowInit.sqf
@@ -1,11 +1,19 @@
 // Plow control with grad_trenches soft dependency.
-// Gated by CBA settings: ADFRC_plow_clearMines and ADFRC_plow_digTrenches.
+// Two-depth system: clearance (mines only) and digging (mines + trenches).
+// Both states use full plow animation; the grad trench dig-in emulates depth.
+// Gated by CBA settings: ADFRC_plow_clearMines, ADFRC_plow_digTrenches,
+// and ADFRC_plow_extraMineClasses.
+// Plow state stored in adfrc_plowState: 0 = raised, 1 = clearance, 2 = digging.
 
 params ["_vehicle"];
 
 if (_vehicle getVariable ["adfrc_plowInitDone", false]) exitWith {};
 _vehicle setVariable ["adfrc_plowInitDone", true];
+_vehicle setVariable ["adfrc_plowState", 0, true];
 
+// =====================================================================
+// SERVER: mine clearing whenever plow is lowered (clearance or digging)
+// =====================================================================
 if (isServer) then {
     [{
         params ["_args", "_handle"];
@@ -16,20 +24,42 @@ if (isServer) then {
         };
 
         if !(missionNamespace getVariable ["ADFRC_plow_clearMines", true]) exitWith {};
-        if ((_vehicle animationPhase "plow") < 0.95) exitWith {};
+
+        // State 1 (clearance) or 2 (digging) both clear mines
+        if ((_vehicle getVariable ["adfrc_plowState", 0]) < 1) exitWith {};
+
+        // Build the class filter: always MineBase + MineGeneric, plus any user-listed extras.
+        // Cache the parsed result, only re-parse when the setting string changes.
+        private _raw = missionNamespace getVariable ["ADFRC_plow_extraMineClasses", ""];
+        private _classes = missionNamespace getVariable ["ADFRC_plow_mineClassCache", []];
+        private _cachedRaw = missionNamespace getVariable ["ADFRC_plow_mineClassCacheRaw", "\n"];
+
+        if !(_raw isEqualTo _cachedRaw) then {
+            _classes = ["MineBase", "MineGeneric"];
+            {
+                private _trimmed = _x splitString " " joinString "";  // strip all spaces
+                if (_trimmed != "") then { _classes pushBackUnique _trimmed };
+            } forEach (_raw splitString ",");
+            missionNamespace setVariable ["ADFRC_plow_mineClassCache", _classes];
+            missionNamespace setVariable ["ADFRC_plow_mineClassCacheRaw", _raw];
+        };
 
         private _searchPos = _vehicle modelToWorld [0, 6, 0];
-        private _mines = nearestObjects [_searchPos, ["MineBase"], 4];
+        private _mines = nearestObjects [_searchPos, _classes, 4];
         { deleteVehicle _x; } forEach _mines;
 
     }, 0.1, [_vehicle]] call CBA_fnc_addPerFrameHandler;
 };
 
-
 if (!hasInterface) exitWith {};
+
+// =====================================================================
+// CLIENTS: state-aware plow actions
+// =====================================================================
 [{
     params ["_vehicle"];
 
+    // Strip grad_trenches' default actions
     for "_i" from 50 to 0 step -1 do {
         private _params = _vehicle actionParams _i;
         if (count _params > 0 && {(_params select 0) in ["Lower Plow", "Raise Plow"]}) then {
@@ -37,53 +67,80 @@ if (!hasInterface) exitWith {};
         };
     };
 
+    // Shared driver/engine/plow-fitted gate
     private _baseCond = "alive _target && {isEngineOn _target} && {(_target animationSourcePhase 'hideplow') == 1} && {_this == driver _target}";
 
-    _vehicle addAction [
-        "Lower plow",
-        {
-            params ["_target"];
-            _target animateDoor ["plow", 1];
+    // Helper: applies a target state to the vehicle. Handles animation,
+    // cruise control, and grad_trenches sync in one place.
+    // State 0 = raised, 1 = clearance, 2 = digging.
+    if (isNil "ADFRC_fnc_setPlowState") then {
+        ADFRC_fnc_setPlowState = {
+            params ["_target", "_state"];
 
-            if (
-                (missionNamespace getVariable ["ADFRC_plow_digTrenches", true])
-                && {isClass (configFile >> "CfgPatches" >> "grad_trenches_functions")}
-            ) then {
+            _target setVariable ["adfrc_plowState", _state, true];
+
+            if (_state > 0) then {
+                _target animateDoor ["plow", 1];
                 _target setCruiseControl [7, false];
-                _target setVariable ["grad_trenches_functions_plowlowered", -1, true];
-                [
-                    { (_this animationPhase "plow") >= 0.99 },
-                    { _this setVariable ["grad_trenches_functions_plowlowered", 1, true] },
-                    _target
-                ] call CBA_fnc_waitUntilAndExecute;
+            } else {
+                _target animateDoor ["plow", 0];
+                _target setCruiseControl [0, false];
             };
-        },
-        nil, 1.5, true, true, "",
-        format ["%1 && {(_target animationPhase 'plow') < 0.5}", _baseCond],
+
+            // grad_trenches digging only at state 2, and only if loaded + enabled
+            private _gradActive = (missionNamespace getVariable ["ADFRC_plow_digTrenches", true])
+                && {isClass (configFile >> "CfgPatches" >> "grad_trenches_functions")};
+
+            if (_gradActive) then {
+                if (_state == 2) then {
+                    // Mark animating, then flag digging once plow reaches full depth
+                    _target setVariable ["grad_trenches_functions_plowlowered", -1, true];
+                    [
+                        { (_this animationPhase "plow") >= 0.99 },
+                        { _this setVariable ["grad_trenches_functions_plowlowered", 1, true] },
+                        _target
+                    ] call CBA_fnc_waitUntilAndExecute;
+                } else {
+                    // Raised or clearance: ensure trench builder is off
+                    _target setVariable ["grad_trenches_functions_plowlowered", 0, true];
+                };
+            };
+        };
+    };
+
+    // ---- Lower to clearance depth (from raised) ----
+    _vehicle addAction [
+        "Lower plow to clearance depth",
+        { [_this select 0, 1] call ADFRC_fnc_setPlowState; },
+        nil, 1.6, true, true, "",
+        format ["%1 && {(_target getVariable ['adfrc_plowState', 0]) == 0}", _baseCond],
         10, false, "", ""
     ];
 
+    // ---- Lower to digging depth (from raised or clearance) ----
+    _vehicle addAction [
+        "Lower plow to digging depth",
+        { [_this select 0, 2] call ADFRC_fnc_setPlowState; },
+        nil, 1.5, true, true, "",
+        format ["%1 && {(_target getVariable ['adfrc_plowState', 0]) in [0, 1]}", _baseCond],
+        10, false, "", ""
+    ];
+
+    // ---- Raise to clearance depth (from digging) ----
+    _vehicle addAction [
+        "Raise plow to clearance depth",
+        { [_this select 0, 1] call ADFRC_fnc_setPlowState; },
+        nil, 1.6, true, true, "",
+        format ["%1 && {(_target getVariable ['adfrc_plowState', 0]) == 2}", _baseCond],
+        10, false, "", ""
+    ];
+
+    // ---- Raise plow fully (from clearance or digging) ----
     _vehicle addAction [
         "Raise plow",
-        {
-            params ["_target"];
-            _target animateDoor ["plow", 0];
-
-            if (
-                (missionNamespace getVariable ["ADFRC_plow_digTrenches", true])
-                && {isClass (configFile >> "CfgPatches" >> "grad_trenches_functions")}
-            ) then {
-                _target setCruiseControl [0, false];
-                _target setVariable ["grad_trenches_functions_plowlowered", -1, true];
-                [
-                    { (_this animationPhase "plow") <= 0.01 },
-                    { _this setVariable ["grad_trenches_functions_plowlowered", 0, true] },
-                    _target
-                ] call CBA_fnc_waitUntilAndExecute;
-            };
-        },
+        { [_this select 0, 0] call ADFRC_fnc_setPlowState; },
         nil, 1.5, true, true, "",
-        format ["%1 && {(_target animationPhase 'plow') >= 0.5}", _baseCond],
+        format ["%1 && {(_target getVariable ['adfrc_plowState', 0]) in [1, 2]}", _baseCond],
         10, false, "", ""
     ];
 


### PR DESCRIPTION
Introduce a two-depth plow system and state management. Adds adfrc_plowState (0=raised,1=clearance,2=digging) and initializes it on vehicles. Server: per-frame mine clearing now respects plow state (clears when state>=1), supports extra mine class list from ADFRC_plow_extraMineClasses with caching (ADFRC_plow_mineClassCache / _Raw), and searches nearestObjects using the combined class list. Client: remove grad_trenches default actions and add a shared helper ADFRC_fnc_setPlowState to handle animation, cruise control and grad_trenches sync. Replace single lower/raise actions with explicit actions for lowering to clearance, lowering to digging, raising to clearance, and raising fully, with appropriate availability conditions and grad_trenches integration only when enabled/loaded. Also gate behavior by CBA settings (ADFRC_plow_clearMines, ADFRC_plow_digTrenches, ADFRC_plow_extraMineClasses).