### PR TITLE
add: LCM1E Landing Craft

### DIFF
--- a/Addons/ADF_Boat/adfrc_lcm/cfg_tiedown.hpp
+++ b/Addons/ADF_Boat/adfrc_lcm/cfg_tiedown.hpp
@@ -1,0 +1,26 @@
+// cfg_tiedown.hpp
+// Tie-down system config.
+//
+// Function tag note: BIS CfgFunctions names functions <TAG>_fnc_<name>, where
+// TAG is the FIRST-level class below CfgFunctions. This must be "adfrc_lcm" so
+// functions compile as adfrc_lcm_fnc_* (which is what all the SQF calls use).
+// The second-level class (TieDown) is just a project subcategory and sets the
+// shared source folder via "file".
+
+class CfgFunctions
+{
+    class adfrc_lcm
+    {
+        class TieDown
+        {
+            file = "ADF_Boat\adfrc_lcm\functions";
+            class preInit       { preInit = 1; };
+            class tieDown       {};
+            class untie         {};
+            class boatInit          {};
+            class addVehicleActions {};
+            class nearestLCM        {};
+            class board             {};
+        };
+    };
+};

--- a/Addons/ADF_Boat/adfrc_lcm/config.cpp
+++ b/Addons/ADF_Boat/adfrc_lcm/config.cpp
@@ -1,0 +1,503 @@
+class CfgPatches
+{
+	class adfrc_lcm
+	{
+		addonRootClass = "A3_Boat_F";
+		requiredAddons[] = {"A3_Boat_F", "cba_main", "cba_xeh"};
+		requiredVersion = 0.1;
+		units[] = {"adfrc_lcm",};
+		weapons[] = {};
+	};
+};
+
+#include "cfg_tiedown.hpp"
+
+class Extended_PreInit_EventHandlers
+{
+	class adfrc_lcm_tiedown_preinit
+	{
+		init = "call adfrc_lcm_fnc_preInit";
+	};
+};
+
+class Extended_Init_EventHandlers;
+
+class DefaultEventHandlers;
+class RCWSOptics;
+class CfgVehicles
+{
+	class Ship_F;
+	class Boat_F: Ship_F
+	{
+		class NewTurret;
+		class Turrets;
+		class ViewPilot;
+		class ViewOptics;
+	};
+	class adfrc_lcm_base: Boat_F
+	{
+		author = "ADFRC - Quiggs";
+		mapSize = 12.72;
+		class SpeechVariants
+		{
+			class Default
+			{
+				speechSingular[] = {"veh_ship_attackBoat_s"};
+				speechPlural[] = {"veh_ship_attackBoat_p"};
+			};
+		};
+		textSingular = "$STR_A3_nameSound_veh_ship_attackBoat_s";
+		textPlural = "$STR_A3_nameSound_veh_ship_attackBoat_p";
+		nameSound = "veh_ship_attackBoat_s";
+		vehicleClass = "Ship";
+		accuracy = 0.5;
+		model = "\ADF_Boat\adfrc_lcm\adfrc_lcm.p3d";
+		editorSubcategory = "EdSubcat_Boats";
+		extCameraPosition[] = {0,2,-25};
+		//picture = "\A3\boat_f\Boat_Armed_01\data\ui\Boat_Armed_01_base.paa";
+		Icon = "\A3\boat_f\Boat_Armed_01\data\ui\map_boat_armed_01.paa";
+		unitInfoType = "RscUnitInfoShip";
+		memoryPointTaskMarker = "TaskMarker_1_pos";
+		slingLoadCargoMemoryPoints[] = {"SlingLoadCargo1","SlingLoadCargo2","SlingLoadCargo3","SlingLoadCargo4","SlingLoadCargo5","SlingLoadCargo6"};
+		attenuationEffectType = "OpenCarAttenuation";
+		insideSoundCoef = 0;
+		soundEngineOnInt[] = {"a3\Sounds_F\vehicles\boat\Boat_Armed_01\Boat_Armed_01-ext-start-02",0.56234133,1.0};
+		soundEngineOnExt[] = {"a3\Sounds_F\vehicles\boat\Boat_Armed_01\Boat_Armed_01-ext-start-02",0.56234133,1.0,200};
+		soundEngineOffInt[] = {"a3\Sounds_F\vehicles\boat\Boat_Armed_01\Boat_Armed_01-ext-stop-02",0.56234133,1.0};
+		soundEngineOffExt[] = {"a3\Sounds_F\vehicles\boat\Boat_Armed_01\Boat_Armed_01-ext-stop-02",0.56234133,1.0,200};
+		buildCrash0[] = {"A3\sounds_f\Vehicles\boat\noises\Metal_boat_crash_building_01",1.7782794,1,200};
+		buildCrash1[] = {"A3\sounds_f\Vehicles\boat\noises\Metal_boat_crash_building_02",1.7782794,1,200};
+		buildCrash2[] = {"A3\sounds_f\Vehicles\boat\noises\Metal_boat_crash_building_03",1.7782794,1,200};
+		soundBuildingCrash[] = {"buildCrash0",0.33,"buildCrash1",0.33,"buildCrash2",0.34};
+		WoodCrash0[] = {"A3\sounds_f\Vehicles\boat\noises\Metal_boat_crash_wood_01",1.7782794,1,200};
+		WoodCrash1[] = {"A3\sounds_f\Vehicles\boat\noises\Metal_boat_crash_wood_02",1.7782794,1,200};
+		WoodCrash2[] = {"A3\sounds_f\Vehicles\boat\noises\Metal_boat_crash_wood_03",1.7782794,1,200};
+		soundWoodCrash[] = {"woodCrash0",0.33,"woodCrash1",0.33,"woodCrash2",0.34};
+		ArmorCrash0[] = {"A3\sounds_f\Vehicles\boat\noises\Metal_boat_crash_armor_01",3.1622777,1,200};
+		ArmorCrash1[] = {"A3\sounds_f\Vehicles\boat\noises\Metal_boat_crash_armor_02",3.1622777,1,200};
+		ArmorCrash2[] = {"A3\sounds_f\Vehicles\boat\noises\Metal_boat_crash_armor_03",3.1622777,1,200};
+		soundArmorCrash[] = {"ArmorCrash0",0.33,"ArmorCrash1",0.33,"ArmorCrash2",0.34};
+		soundGeneralCollision1[] = {"A3\sounds_f\Vehicles\boat\noises\Metal_boat_crash_armor_01",1.7782794,1,100};
+		soundGeneralCollision2[] = {"A3\sounds_f\Vehicles\boat\noises\Metal_boat_crash_armor_02",1.7782794,1,100};
+		soundGeneralCollision3[] = {"A3\sounds_f\Vehicles\boat\noises\Metal_boat_crash_armor_03",1.7782794,1,100};
+		soundCrashes[] = {"soundGeneralCollision1",0.33,"soundGeneralCollision2",0.33,"soundGeneralCollision3",0.34};
+		class Sounds
+		{
+			class IdleOut
+			{
+				sound[] = {"A3\Sounds_F\vehicles\boat\Boat_Armed_01\Boat_Armed_01-idle-2",0.5011872,1.0,300};
+				frequency = "0.95	+	((rpm/	1200) factor[(100/	1200),(300/	1200)])*0.15";
+				volume = "engineOn*(((rpm/	1200) factor[(0/	1200),(30/	1200)])	*	((rpm/	1200) factor[(500/	1200),(300/	1200)]))";
+			};
+			class Engine
+			{
+				sound[] = {"A3\Sounds_F\vehicles\boat\Boat_Armed_01\Boat_Armed_01-low-2",0.63095737,1.0,450};
+				frequency = "0.95	+	((rpm/	1200) factor[(300/	1200),(600/	1200)])*0.2";
+				volume = "engineOn*(((rpm/	1200) factor[(150/	1200),(250/	1200)])	*	((rpm/	1200) factor[(600/	1200),(400/	1200)]))";
+			};
+			class EngineMidOut
+			{
+				sound[] = {"A3\Sounds_F\vehicles\boat\Boat_Armed_01\Boat_Armed_01-mid-2",0.7943282,1.0,500};
+				frequency = "0.95	+		((rpm/	1200) factor[(600/	1200),(900/	1200)])*0.2";
+				volume = "engineOn*(((rpm/	1200) factor[(350/	1200),(500/	1200)])	*	((rpm/	1200) factor[(1000/	1200),(700/	1200)]))";
+			};
+			class EngineMaxOut
+			{
+				sound[] = {"A3\Sounds_F\vehicles\boat\Boat_Armed_01\Boat_Armed_01-high-2",1.0,1.0,600};
+				frequency = "0.95	+	((rpm/	1200) factor[(700/	1200),(1000/	1200)])*0.2";
+				volume = "engineOn*((rpm/	1200) factor[(800/	1200),(1200/	1200)])";
+			};
+			class WaternoiseOutW0
+			{
+				sound[] = {"A3\Sounds_F\vehicles\boat\SFX\voda-o-bok-lodi-0-speed1",0.70794576,1.0,150};
+				frequency = "1";
+				volume = "(speed factor[4, 1]) * water";
+			};
+			class WaternoiseOutW1
+			{
+				sound[] = {"A3\Sounds_F\vehicles\boat\SFX\voda-o-bok-lodi-20-speed",0.7943282,1.0,250};
+				frequency = "1";
+				volume = "((speed factor[2, 6]) min (speed factor[6, 4]))";
+			};
+			class WaternoiseOutW2
+			{
+				sound[] = {"A3\Sounds_F\vehicles\boat\SFX\voda-o-bok-lodi-50-speed",1.0,1.0,350};
+				frequency = "1";
+				volume = "(speed factor[3, 9])";
+			};
+			class WaternoiseOutW3
+			{
+				sound[] = {"A3\Sounds_F\vehicles\boat\SFX\voda-o-bok-lodi-0-speed1",0.70794576,1.0,150};
+				frequency = "1";
+				volume = "(speed factor[-4, -1]) * water";
+			};
+			class WaternoiseOutW4
+			{
+				sound[] = {"A3\Sounds_F\vehicles\boat\SFX\voda-o-bok-lodi-20-speed",0.7943282,0.9,250};
+				frequency = "1";
+				volume = "((speed factor[-2, -6]) min (speed factor[-6, -4]))";
+			};
+			class WaternoiseOutW5
+			{
+				sound[] = {"A3\Sounds_F\vehicles\boat\SFX\voda-o-bok-lodi-50-speed",1.0,0.9,350};
+				frequency = "1";
+				volume = "(speed factor[-3, -9])";
+			};
+			class scrubLandExt
+			{
+				sound[] = {"A3\Sounds_F\vehicles\boat\noises\boat_land_on_shallow",1.7782794,0.9,100};
+				frequency = 1;
+				volume = "(scrubLand factor[0.01, 0.20])";
+			};
+			class RainExt
+			{
+				sound[] = {"A3\Sounds_F\vehicles\noises\rain1_ext",1.0,1.0,100};
+				frequency = 1;
+				volume = "camPos * (rain - rotorSpeed/2) * 2";
+			};
+			class RainInt
+			{
+				sound[] = {"A3\Sounds_F\vehicles\noises\rain1_ext",1.0,1.0,100};
+				frequency = 1;
+				volume = "(1-camPos)*(rain - rotorSpeed/2)*2";
+			};
+		};
+		class RenderTargets
+		{
+			class driver_display_1
+			{
+				renderTarget = "rendertarget0";
+				class CameraView1
+				{
+					pointPosition = "PIP0_pos";
+					pointDirection = "PIP0_dir";
+					renderVisionMode = 1;
+					renderQuality = 0;
+					fov = 0.4;
+				};
+				BBoxes[] = {"PIP_0_TL","PIP_0_TR","PIP_0_BL","PIP_0_BR"};
+			};
+			class Gunner_1
+			{
+				renderTarget = "rendertarget3";
+				class CameraView1
+				{
+					pointPosition = "PIP3_pos";
+					pointDirection = "PIP3_dir";
+					renderVisionMode = 0;
+					renderQuality = 0;
+					fov = 0.5;
+				};
+				BBoxes[] = {"PIP_3_TL","PIP_3_TR","PIP_3_BL","PIP_3_BR"};
+			};
+			class Gunner_TV
+			{
+				renderTarget = "rendertarget4";
+				class CameraView1
+				{
+					pointPosition = "PIP3_pos";
+					pointDirection = "PIP3_dir";
+					renderVisionMode = 2;
+					renderQuality = 0;
+					fov = 0.7;
+				};
+				BBoxes[] = {"PIP_4_TL","PIP_4_TR","PIP_4_BL","PIP_4_BR"};
+			};
+		};
+		armor = 400;
+		class HitPoints
+		{
+			class HitBody
+			{
+				armor = 0.2;
+				material = 50;
+				name = "karoserie";
+				visual = "zbytek";
+				passThrough = 1;
+				explosionShielding = 2;
+			};
+			class HitEngine
+			{
+				armor = 0.6;
+				material = -1;
+				armorComponent = "hit_engine";
+				name = "hit_engine_point";
+				visual = "-";
+				passThrough = 0.5;
+				minimalHit = 0.2;
+				explosionShielding = 0.2;
+				radius = 0.3;
+			};
+			class HitFuel
+			{
+				armor = 0.5;
+				material = -1;
+				armorComponent = "hit_fuel";
+				name = "hit_fuel_point";
+				visual = "-";
+				passThrough = 0.3;
+				minimalHit = 0.1;
+				explosionShielding = 0.6;
+				radius = 0.3;
+			};
+		};
+		driverLeftHandAnimName = "drivewheel";
+		driverRightHandAnimName = "drivewheel";
+		driverAction = "driver_boat01";
+		cargoAction[] = {"passenger_boat_rightrear","passenger_flatground_leanright","passenger_boat_holdright2","passenger_boat_holdleft2","passenger_flatground_leanright","passenger_flatground_leanleft","passenger_boat_holdright","passenger_boat_holdleft"};
+		getInAction = "GetInLow";
+		getOutAction = "GetOutBoat";
+		cargoGetInAction[] = {"GetInLow"};
+		cargoGetOutAction[] = {"GetOutBoat"};
+		castDriverShadow = 1;
+		castCargoShadow = 1;
+		gunnerHasFlares = 0;
+		enableGPS = 1;
+		enableRadio = 1;
+		transportSoldier = 8;
+		class TransportItems
+		{
+			class _xx_FirstAidKit
+			{
+				name = "FirstAidKit";
+				count = 10;
+			};
+			class _xx_medikit
+			{
+				name = "medikit";
+				count = 1;
+			};
+		};
+		steerAheadSimul = 0.5;
+		steerAheadPlan = 0.35;
+		predictTurnPlan = 0.8;
+		predictTurnSimul = 0.6;
+		acceleration = 8;
+		turnCoef = 1;
+		maxSpeed = 50;
+		simulation = "shipx";
+		thrustDelay = 0.35;
+		overSpeedBrakeCoef = 0.2;
+		enginePower = 1600;
+		engineShiftY = 2;
+		waterLeakiness = 1000;
+		waterLinearDampingCoefY = 10;
+		waterLinearDampingCoefX = 10;
+		waterAngularDampingCoef = 25;
+		waterResistanceCoef = 0.01;
+		rudderForceCoef = 2;
+		rudderForceCoefAtMaxSpeed = 0.45;
+		idleRpm = 200;
+		redRpm = 1400;
+		class complexGearbox
+		{
+			GearboxRatios[] = {"R1",-0.782,"N",0,"D1",2.0,"D2",1.85,"D3",1.75};
+			TransmissionRatios[] = {"High",1.0};
+			gearBoxMode = "auto";
+			moveOffGear = 1;
+			driveString = "D";
+			neutralString = "N";
+			reverseString = "R";
+		};
+		enableManualFire = 0;
+		smokeLauncherGrenadeCount = 8;
+		smokeLauncherVelocity = 14;
+		smokeLauncherOnTurret = 0;
+		smokeLauncherAngle = 360;
+		weapons[] = {"SmokeLauncher"};
+		magazines[] = {"SmokeLauncherMag_boat"};
+		class Exhausts
+		{
+			class Exhaust1
+			{
+				position = "Exhaust1";
+				direction = "Exhaust1_dir";
+				effect = "";
+			};
+		};
+		leftFastWaterEffect = "LFastWaterEffects";
+		rightFastWaterEffect = "RFastWaterEffects";
+		waterEffectSpeed = 3;
+		engineEffectSpeed = 3;
+		waterFastEffectSpeed = 20;
+		class AnimationSources
+		{
+			class ramp_front
+			{
+				source="door";
+				initPhase=0;
+				animPeriod=6;
+				sound = "ServoRampSound_2";
+			};
+			class ramp_rear
+			{
+				source="door";
+				initPhase=0;
+				animPeriod=6;
+				sound = "ServoRampSound_2";
+			};
+		};
+		class ViewPilot: ViewPilot
+		{
+			initAngleX = -15;
+		};
+		class Turrets
+		{};
+		class Library
+		{
+			libTextDesc = "$STR_A3_CfgVehicles_Boat_Armed_01_Base_Library0";
+		};
+		class Damage
+		{
+			tex[] = {};
+			mat[] = {"A3\boat_F\Boat_Armed_01\data\Boat_Armed_01_ext.rvmat","A3\boat_F\Boat_Armed_01\data\Boat_Armed_01_ext_damage.rvmat","A3\boat_F\Boat_Armed_01\data\Boat_Armed_01_ext_destruct.rvmat","A3\boat_F\Boat_Armed_01\data\Boat_Armed_01_int.rvmat","A3\boat_F\Boat_Armed_01\data\Boat_Armed_01_int_damage.rvmat","A3\boat_F\Boat_Armed_01\data\Boat_Armed_01_int_destruct.rvmat","A3\boat_F\Boat_Armed_01\data\Boat_Armed_01_ctrls.rvmat","A3\boat_F\Boat_Armed_01\data\Boat_Armed_01_ctrls_damage.rvmat","A3\boat_F\Boat_Armed_01\data\Boat_Armed_01_ctrls_destruct.rvmat","A3\Static_F_Gamma\data\staticturret_01.rvmat","A3\Static_F_Gamma\data\StaticTurret_01_damage.rvmat","A3\Static_F_Gamma\data\StaticTurret_01_destruct.rvmat","A3\Static_F_Gamma\data\staticturret_02.rvmat","A3\Static_F_Gamma\data\StaticTurret_02_damage.rvmat","A3\Static_F_Gamma\data\StaticTurret_02_destruct.rvmat","a3\boat_f\Boat_Armed_01\data\Minigun.rvmat","A3\boat_f\Boat_Armed_01\data\Minigun_damage.rvmat","A3\boat_f\Boat_Armed_01\data\Minigun_destruct.rvmat","a3\boat_f\Boat_Armed_01\data\Minigun_Boat_Armed_01_add.rvmat","A3\boat_f\Boat_Armed_01\data\Minigun_Boat_Armed_01_add_damage.rvmat","A3\boat_f\Boat_Armed_01\data\Minigun_Boat_Armed_01_add_destruct.rvmat","a3\Data_F\Vehicles\Turret.rvmat","A3\Data_F\Vehicles\Turret_damage.rvmat","A3\Data_F\Vehicles\Turret_destruct.rvmat"};
+		};
+		class Reflectors
+		{
+			class Left
+			{
+				color[] = {1900,1800,1700};
+				ambient[] = {5,5,5};
+				position = "Light_L_pos";
+				direction = "Light_L_dir";
+				hitpoint = "Light_L";
+				selection = "Light_L";
+				size = 1;
+				innerAngle = 100;
+				outerAngle = 179;
+				coneFadeCoef = 10;
+				intensity = 1;
+				useFlare = 0;
+				dayLight = 0;
+				flareSize = 1.0;
+				class Attenuation
+				{
+					start = 1.0;
+					constant = 0;
+					linear = 0;
+					quadratic = 0.25;
+					hardLimitStart = 30;
+					hardLimitEnd = 60;
+				};
+			};
+			class Right: Left
+			{
+				position = "Light_R_pos";
+				direction = "Light_R_dir";
+				hitpoint = "Light_R";
+				selection = "Light_R";
+			};
+			class Right2: Right
+			{
+				position = "Light_R_pos";
+				hitpoint = "Light_R_flare";
+				useFlare = 1;
+			};
+			class Left2: Left
+			{
+				position = "light_L_pos";
+				hitpoint = "Light_L_flare";
+				useFlare = 1;
+			};
+			class Deck: Left
+			{
+				position = "Light_deck_pos";
+				direction = "Light_deck_dir";
+				hitpoint = "Light_deck";
+				selection = "Light_deck";
+			};
+			class Deck2: Deck
+			{
+				position = "Light_deck_pos";
+				hitpoint = "Light_deck_flare";
+				useFlare = 1;
+			};
+		};
+		aggregateReflectors[] = {{"Right","Right2"}};
+		class UserActions
+		{
+			class open_front_ramp
+			{
+				userActionID=50;
+				displayName="Lower Front Ramp";
+				radius=5;
+				showIn3D=17;
+				priority=1;
+				position="driverview";
+				onlyForPlayer=0;
+				condition="((this DoorPhase 'ramp_front') == 0) AND Alive (this) and driver this == player";
+				statement="this animateDoor ['ramp_front', 1];";
+			};
+			class close_front_ramp: open_front_ramp
+			{
+				userActionID=51;
+				displayName="Raise Front Ramp";
+				condition="((this DoorPhase 'ramp_front') > 0) AND Alive (this) and driver this == player";
+				statement="this animateDoor [""ramp_front"", 0];";
+			};
+			class open_rear_ramp
+			{
+				userActionID=50;
+				displayName="Lower Rear Ramp";
+				radius=5;
+				showIn3D=17;
+				priority=1;
+				position="driverview";
+				onlyForPlayer=0;
+				condition="((this DoorPhase 'ramp_rear') == 0) AND Alive (this) and driver this == player";
+				statement="this animateDoor ['ramp_rear', 1];";
+			};
+			class close_rear_ramp: open_rear_ramp
+			{
+				userActionID=51;
+				displayName="Raise Rear Ramp";
+				condition="((this DoorPhase 'ramp_rear') > 0) AND Alive (this) and driver this == player";
+				statement="this animateDoor [""ramp_rear"", 0];";
+			};
+		};
+		class VehicleTransport
+		{
+			class Cargo
+			{
+				canBeTransported = 0;
+			};
+			// ViV Carrier disabled - tie-down system replaces it.
+			// maxLoadMass 0 + canBeTransported guards stop the ViV load action
+			// appearing alongside the scroll-wheel tie-down.
+			class Carrier
+			{
+				cargoBayDimensions[] = {};
+				disableHeightLimit = 0;
+				maxLoadMass = 0;
+				cargoAlignment[] = {"center","front"};
+				cargoSpacing[] = {0,0,0};
+				exits[] = {};
+				unloadingInterval = 2;
+				loadingDistance = 5.0;
+				loadingAngle = 60.0;
+				parachuteClassDefault = "B_Parachute_02_F";
+				parachuteHeightLimitDefault = 5;
+			};
+		};
+	};
+	class adfrc_lcm: adfrc_lcm_base
+	{
+		author = "ADFRC - Quiggs";
+		//editorPreview = "\A3\EditorPreviews_F\Data\CfgVehicles\B_Boat_Armed_01_minigun_F.jpg";
+		displayName = "LCM-1E";
+		scope = 2;
+		scopeCurator = 2;
+		accuracy = 1.5;
+		crew = "B_soldier_F";
+		faction = "BLU_F";
+		side = 1;
+		typicalCargo[] = {"B_Soldier_F","B_Soldier_F"};
+		class Extended_Init_EventHandlers
+		{
+			class adfrc_lcm_tiedown
+			{
+				init = "(_this select 0) call adfrc_lcm_fnc_boatInit";
+			};
+		};
+	};
+};

--- a/Addons/ADF_Boat/adfrc_lcm/data/textures/lcm1e_Material.rvmat
+++ b/Addons/ADF_Boat/adfrc_lcm/data/textures/lcm1e_Material.rvmat
@@ -1,0 +1,48 @@
+class StageTI
+{
+	//texture = "lex_aa\lcm1e_Material_ti_ca.paa";
+};
+ambient[] = {1,1,1,1};
+diffuse[] = {1,1,1,1};
+forcedDiffuse[] = {0,0,0,1};
+emmisive[] = {0,0,0,1};
+specular[] = {0.15,0.15,0.15,1};
+specularPower = 15;
+PixelShaderID = "Super";
+VertexShaderID = "Super";
+class Stage1
+{
+	texture = "ADF_Boat\adfrc_lcm\data\textures\lcm1e_Material_nohq.paa";
+	uvSource = "tex";
+};
+class Stage2
+{
+	texture = "#(argb,8,8,3)color(0.5,0.5,0.5,1,DT)";
+	uvSource = "tex";
+};
+class Stage3
+{
+	texture = "#(argb,8,8,3)color(0,0,0,0,MC)";
+	uvSource = "tex";
+};
+class Stage4
+{
+	texture = "ADF_Boat\adfrc_lcm\data\textures\lcm1e_Material_as.paa";
+	uvSource = "tex";
+};
+class Stage5
+{
+	texture = "ADF_Boat\adfrc_lcm\data\textures\lcm1e_Material_smdi.paa";
+	uvSource = "tex";
+};
+class Stage6
+{
+	texture = "#(ai,64,64,1)fresnel(4.7,1.2)";
+	uvSource = "tex";
+};
+class Stage7
+{
+	texture = "a3\data_f\env_land_co.paa";
+	useWorldEnvMap = "true";
+	uvSource = "tex";
+};

--- a/Addons/ADF_Boat/adfrc_lcm/data/textures/lcm1e_Material_as.paa
+++ b/Addons/ADF_Boat/adfrc_lcm/data/textures/lcm1e_Material_as.paa
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bea4bc3d8297fbfc703404370087bb84c06e773327d6cb1fef8e8a420b5d480f
+size 3596889

--- a/Addons/ADF_Boat/adfrc_lcm/data/textures/lcm1e_Material_co.paa
+++ b/Addons/ADF_Boat/adfrc_lcm/data/textures/lcm1e_Material_co.paa
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53359d18a6c2b566815462170f352752682638c70f67a4e88ec6575ddb481395
+size 6393728

--- a/Addons/ADF_Boat/adfrc_lcm/data/textures/lcm1e_Material_nohq.paa
+++ b/Addons/ADF_Boat/adfrc_lcm/data/textures/lcm1e_Material_nohq.paa
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bdbf0927e851fdc98e734441bbe91582480ebaf66166e548531f2e5680f3422f
+size 10786565

--- a/Addons/ADF_Boat/adfrc_lcm/data/textures/lcm1e_Material_smdi.paa
+++ b/Addons/ADF_Boat/adfrc_lcm/data/textures/lcm1e_Material_smdi.paa
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d008ea872c679736d76e9b3416146341623e2220087e0498b3237b94621bd64
+size 5060859

--- a/Addons/ADF_Boat/adfrc_lcm/functions/fn_addVehicleActions.sqf
+++ b/Addons/ADF_Boat/adfrc_lcm/functions/fn_addVehicleActions.sqf
@@ -1,0 +1,66 @@
+/*
+    adfrc_lcm_fnc_addVehicleActions
+
+    Adds the tie-down / release scroll actions to a vehicle. Attached to all
+    vehicles via a CBA class init event handler (see preInit) so the driver
+    sees the action in their own scroll menu while seated - an addAction on the
+    boat would not reach a player sealed inside a vehicle.
+
+    The action finds the nearest LCM in range at evaluation time, so no boat
+    reference needs to be wired up front.
+
+    Params (from class init EH):
+        0: VEHICLE <OBJECT>
+
+    Returns: nothing
+*/
+params ["_veh"];
+
+if (!hasInterface) exitWith {};
+
+// don't add to the LCM itself or to non-vehicles
+if (_veh isKindOf "adfrc_lcm_base") exitWith {};
+if !(_veh isKindOf "LandVehicle") exitWith {};   // cars, tanks, APCs; skip men/boats/air by default
+
+// guard against double-add (JIP + init both firing)
+if (_veh getVariable ["adfrc_lcm_actionsAdded", false]) exitWith {};
+_veh setVariable ["adfrc_lcm_actionsAdded", true];
+
+_veh addAction [
+    "<t color='#8cff9b'>Tie Down to Landing Craft</t>",
+    {
+        params ["_veh", "_caller", "_actionId", "_args"];
+        private _boat = [_veh] call adfrc_lcm_fnc_nearestLCM;
+        if (isNull _boat) exitWith { hint "No landing craft in range"; };
+        [_boat, _veh] call adfrc_lcm_fnc_tieDown;
+    },
+    nil,
+    1.5,
+    false,
+    true,
+    "",
+    "
+        _this == (driver _target) &&
+        {!(_target getVariable ['adfrc_tiedDown', false])} &&
+        {!isNull ([_target] call adfrc_lcm_fnc_nearestLCM)}
+    ",
+    -1
+];
+
+_veh addAction [
+    "<t color='#ff8c8c'>Release from Landing Craft</t>",
+    {
+        params ["_veh", "_caller", "_actionId", "_args"];
+        [_veh] call adfrc_lcm_fnc_untie;
+    },
+    nil,
+    1.5,
+    false,
+    true,
+    "",
+    "
+        _this == (driver _target) &&
+        {_target getVariable ['adfrc_tiedDown', false]}
+    ",
+    -1
+];

--- a/Addons/ADF_Boat/adfrc_lcm/functions/fn_board.sqf
+++ b/Addons/ADF_Boat/adfrc_lcm/functions/fn_board.sqf
@@ -1,0 +1,59 @@
+/*
+    adfrc_lcm_fnc_board
+
+    Self-board: a swimmer places themselves onto the LCM deck. Runs on the
+    swimmer's own machine (they are local to themselves), so the position
+    write lands on the sim owner with no locality routing needed.
+
+    Placement target priority:
+        1. boat memory point "adfrc_board_pos" (add to p3d when convenient)
+        2. fallback: deck-relative model offset adfrc_lcm_boardOffset
+
+    The unit is placed slightly above the deck and allowed to settle, which
+    avoids the swim->stand transition flinging them at boat speed.
+
+    Params:
+        0: BOAT <OBJECT>
+        1: UNIT <OBJECT> - the boarding swimmer (should be the local player)
+
+    Returns: nothing
+*/
+params ["_boat", "_unit"];
+
+if (isNull _boat || isNull _unit) exitWith {};
+if (!local _unit) exitWith {
+    [_boat, _unit] remoteExec ["adfrc_lcm_fnc_board", _unit];
+};
+
+// must actually be in/near water and on foot
+if (!isNull objectParent _unit) exitWith {};
+if (vehicle _unit != _unit) exitWith {};
+
+private _range = missionNamespace getVariable ["ADFRC_lcm_boardRange", 8];
+if (_unit distance _boat > _range) exitWith {};
+
+// resolve deck target
+private _memPos = _boat selectionPosition "adfrc_board_pos";
+private _targetModel = if (_memPos isEqualTo [0,0,0]) then {
+    // fallback offset: x=right, y=fwd, z=up, relative to boat model origin
+    missionNamespace getVariable ["adfrc_lcm_boardOffset", [0, -2, 0.6]]
+} else {
+    _memPos
+};
+
+private _targetWorld = _boat modelToWorldVisual _targetModel;
+// lift slightly so they settle onto the deck instead of clipping through
+_targetWorld set [2, (_targetWorld select 2) + 0.4];
+
+// brief swim->stand settle to avoid fling at speed
+[_unit, _targetWorld, _boat] spawn {
+    params ["_unit", "_pos", "_boat"];
+    _unit setPosWorld _pos;
+    _unit setVectorDirAndUp [_boat vectorModelToWorld [0,1,0], _boat vectorModelToWorld [0,0,1]];
+    _unit setVelocity [0,0,0];
+    // settle frame: re-seat once after the engine processes the move
+    uiSleep 0.05;
+    if (alive _unit && {!isNull _boat}) then {
+        _unit setVelocity (velocity _boat);
+    };
+};

--- a/Addons/ADF_Boat/adfrc_lcm/functions/fn_boatInit.sqf
+++ b/Addons/ADF_Boat/adfrc_lcm/functions/fn_boatInit.sqf
@@ -1,0 +1,35 @@
+/*
+    adfrc_lcm_fnc_boatInit
+
+    Runs on each machine via XEH init on the boat. Adds the "Board Landing
+    Craft" scroll action for swimmers/dismounts on foot near the boat.
+
+    Params (from XEH):
+        0: BOAT <OBJECT>
+
+    Returns: nothing
+*/
+params ["_boat"];
+
+if (!hasInterface) exitWith {};
+
+// --- Board landing craft (self-board for swimmers / dismounts on foot) ---
+_boat addAction [
+    "<t color='#8cd0ff'>Board Landing Craft</t>",
+    {
+        params ["_boat", "_caller", "_actionId", "_args"];
+        [_boat, _caller] call adfrc_lcm_fnc_board;
+    },
+    nil,
+    1.4,
+    true,
+    true,
+    "",
+    "
+        (vehicle _this == _this) &&
+        {isNull (objectParent _this)} &&
+        {_this distance _target < (missionNamespace getVariable ['ADFRC_lcm_boardRange', 8])} &&
+        {(getPosASL _this) select 2 < 1}
+    ",
+    (missionNamespace getVariable ["ADFRC_lcm_boardRange", 8])
+];

--- a/Addons/ADF_Boat/adfrc_lcm/functions/fn_nearestLCM.sqf
+++ b/Addons/ADF_Boat/adfrc_lcm/functions/fn_nearestLCM.sqf
@@ -1,0 +1,20 @@
+/*
+    adfrc_lcm_fnc_nearestLCM
+
+    Returns the nearest LCM within tie-down range of the given vehicle, or
+    objNull if none. Used by the vehicle-side action condition and statement.
+
+    Params:
+        0: VEHICLE <OBJECT>
+
+    Returns: <OBJECT> nearest LCM in range, or objNull
+*/
+params ["_veh"];
+
+if (isNull _veh) exitWith {objNull};
+
+private _range = missionNamespace getVariable ["ADFRC_lcm_tieRange", 12];
+private _boats = nearestObjects [_veh, ["adfrc_lcm_base"], _range];
+
+if (_boats isEqualTo []) exitWith {objNull};
+_boats select 0;

--- a/Addons/ADF_Boat/adfrc_lcm/functions/fn_preInit.sqf
+++ b/Addons/ADF_Boat/adfrc_lcm/functions/fn_preInit.sqf
@@ -1,0 +1,25 @@
+/*
+    adfrc_lcm_fnc_preInit
+
+    preInit-time runtime setup for the LCM tie-down / boarding system.
+
+    CBA settings are NOT registered here - they live in ADF_Core's
+    initSettings.sqf (ADFRC_lcm_tieRange, ADFRC_lcm_boardRange), consistent
+    with the rest of the mod's settings.
+
+    With the attachTo + enableSimulationGlobal approach the attachment and
+    freeze replicate and persist on their own, so there is no enforcement loop
+    or ownership watchdog - this just attaches the tie/release scroll actions
+    to all land vehicles.
+
+    Params: none
+    Returns: nothing
+*/
+
+// attach tie/release actions to every land vehicle (clients only need them)
+if (hasInterface) then {
+    ["LandVehicle", "InitPost", {
+        params ["_veh"];
+        [_veh] call adfrc_lcm_fnc_addVehicleActions;
+    }, true, [], true] call CBA_fnc_addClassEventHandler;
+};

--- a/Addons/ADF_Boat/adfrc_lcm/functions/fn_tieDown.sqf
+++ b/Addons/ADF_Boat/adfrc_lcm/functions/fn_tieDown.sqf
@@ -1,0 +1,55 @@
+/*
+    adfrc_lcm_fnc_tieDown
+
+    Ties a vehicle to the LCM using attachTo + simulation freeze.
+
+    The vehicle is attached to the boat at its current relative position, then
+    its simulation is disabled globally. attachTo parents the vehicle to the
+    boat's frame so it rides along natively (no per-frame catch-up, no
+    choppiness). enableSimulationGlobal false freezes physics/anim but leaves
+    crew seated - troops stay boarded, they just can't operate the vehicle
+    until released.
+
+    Server-authoritative: attachTo and enableSimulationGlobal must run on the
+    server to replicate to all machines. The attachment and freeze persist
+    across ownership changes (driver leaving, swapping, disconnecting) on their
+    own,so no enforcement loop needed.
+
+    Params:
+        0: BOAT    <OBJECT>
+        1: VEHICLE <OBJECT>
+
+    Returns: nothing
+*/
+params ["_boat", "_vehicle"];
+
+if (!isServer) exitWith {
+    [_boat, _vehicle] remoteExec ["adfrc_lcm_fnc_tieDown", 2];
+};
+
+if (isNull _boat || isNull _vehicle) exitWith {};
+if (_vehicle getVariable ["adfrc_tiedDown", false]) exitWith {};
+
+// range sanity check
+private _maxDist = missionNamespace getVariable ["ADFRC_lcm_tieRange", 12];
+if (_vehicle distance _boat > _maxDist) exitWith {};
+
+// capture current position + orientation relative to the boat (model space)
+private _relPos = _boat worldToModel (getPosWorld _vehicle);
+private _vDir   = _boat vectorWorldToModel (vectorDir _vehicle);
+private _vUp    = _boat vectorWorldToModel (vectorUp _vehicle);
+
+_vehicle setVariable ["adfrc_tieBoat", _boat, true];
+_vehicle setVariable ["adfrc_tiedDown", true, true];
+
+// attach at the captured offset
+_vehicle attachTo [_boat, _relPos];
+
+// attachTo resets orientation to boat-relative default; restore the parked
+// heading. For an ATTACHED object, setVectorDirAndUp takes vectors in the
+// PARENT's model space - so feed the captured model-space vectors directly
+// (do NOT transform back to world).
+_vehicle setVectorDirAndUp [_vDir, _vUp];
+
+// freeze physics/animation; crew remain seated
+_vehicle enableSimulationGlobal false;

--- a/Addons/ADF_Boat/adfrc_lcm/functions/fn_untie.sqf
+++ b/Addons/ADF_Boat/adfrc_lcm/functions/fn_untie.sqf
@@ -1,0 +1,38 @@
+/*
+    adfrc_lcm_fnc_untie
+
+    Releases a tied-down vehicle: re-enable simulation, detach, settle it onto
+    the surface. Server-authoritative (detach + enableSimulationGlobal must run
+    server-side to replicate).
+
+    Params:
+        0: VEHICLE <OBJECT>
+
+    Returns: nothing
+*/
+params ["_vehicle"];
+
+if (!isServer) exitWith {
+    [_vehicle] remoteExec ["adfrc_lcm_fnc_untie", 2];
+};
+
+if (isNull _vehicle) exitWith {};
+if (!(_vehicle getVariable ["adfrc_tiedDown", false])) exitWith {};
+
+// re-enable sim before detaching so physics resumes cleanly
+_vehicle enableSimulationGlobal true;
+
+// capture world pos/orientation before detach so it doesn't snap
+private _wPos = getPosWorld _vehicle;
+private _wDir = vectorDir _vehicle;
+private _wUp  = vectorUp _vehicle;
+
+detach _vehicle;
+
+// re-place at the exact spot it was attached (detach can nudge it)
+_vehicle setPosWorld _wPos;
+_vehicle setVectorDirAndUp [_wDir, _wUp];
+_vehicle setVelocity [0,0,0];
+
+_vehicle setVariable ["adfrc_tiedDown", false, true];
+_vehicle setVariable ["adfrc_tieBoat", objNull, true];

--- a/Addons/ADF_Boat/adfrc_lcm/model.cfg
+++ b/Addons/ADF_Boat/adfrc_lcm/model.cfg
@@ -1,0 +1,62 @@
+class cfgSkeletons
+{
+	class adfrc_lcm
+	{
+		isDiscrete = 0;
+		skeletonInherit = "";
+		SkeletonBones[]=
+		{
+			
+			"ramp_front"	,"",
+			"ramp_rear"		,"",
+			
+		};
+	};
+};	
+class CfgModels
+{	
+	class Default
+	{
+		sections[] = {};
+		sectionsInherit="";
+		skeletonName = "";
+	};
+	class adfrc_lcm: Default
+	{
+		skeletonName="adfrc_lcm";
+		sectionsInherit="";
+		sections[]=
+		{
+			"light_l",
+			"light_r",
+			"light_deck",
+			"zbytek",
+			"clan"
+		};
+		class Animations
+		{
+			class ramp_front
+			{
+				type="rotation";
+				source="ramp_front";
+				selection="ramp_front";
+				axis="ramp_front_axis";
+				animPeriod=0;
+				angle0=0;
+				angle1="rad -70";
+				memory = 1;	
+			};
+			class ramp_rear
+			{
+				type="rotation";
+				source="ramp_rear";
+				selection="ramp_rear";
+				axis="ramp_rear_axis";
+				animPeriod=0;
+				angle0=0;
+				angle1="rad -90";
+				memory = 1;	
+			};
+		};
+	};
+};

--- a/Addons/ADF_Boat/config.cpp
+++ b/Addons/ADF_Boat/config.cpp
@@ -1,0 +1,11 @@
+class CfgPatches
+{
+	class ADF_Boat
+	{
+		units[] = {};
+		weapons[] = {};
+		requiredVersion = 0.1;
+		requiredAddons[] = {"ADF_Core"};
+		fileName = "ADF_Boat.pbo";
+	};
+};


### PR DESCRIPTION
implement functional LCM-1E based on images of RAN usage from Canberra-class LHD
Whilst normally a RAN asset, fits into scope of ADFRC due to Australian Army's white paper goals of strengthening it's littoral capabilities.

Vessel has scripts running to manage 'tie-down' of vehicles onto the deck, disabling their simulation and attaching them to the deck. This uses scroll wheel actions for the drivers of the vehicles, not the helmsman of the boat. This is a first release and additional features are welcome to be added by the community and/or suggestions made for model changes to facilitate those features.
Additional scroll wheel action added for swimmers to 'board' which moves them onto the deck, because I know how painful it is to disembark into the water accidentally and not be able to get back onto a boat.

ViV version to be planned for addition later (latticework is present in the config).

Kudos to @Quiggsleyy for 95% of the work on this asset. I just bought the model and implemented the scripting at the tail end.