### PR TITLE
Modified visionMode array

### DIFF
--- a/Addons/ADF_Wheeled/adfrc_aslav/config.cpp
+++ b/Addons/ADF_Wheeled/adfrc_aslav/config.cpp
@@ -1946,7 +1946,6 @@ class CfgVehicles
 					initFov = 0.9;
 					minFov = 0.25;
 					maxFov = 0.9;
-					visionMode[] = {"Normal"};
 				};
 				class TurnIn
                 {
@@ -2753,7 +2752,6 @@ class CfgVehicles
 							initFov = 0.9;
 							minFov = 0.25;
 							maxFov = 0.9;
-							visionMode[] = {"Normal"};
 						};
 						class OpticsIn{};
 						class HitPoints


### PR DESCRIPTION
Removed the visionMode array from M2 and Mag 58 turrets on ASLAVS were turned out turrets are used.

This allows for player night vision to be used when ADS.