### PR TITLE
Restored Belt Box Textures

### DIFF
--- a/Addons/ADF_Weapons/adfrc_mag58/Textures/adfrc_AmmoMag58_CO.paa
+++ b/Addons/ADF_Weapons/adfrc_mag58/Textures/adfrc_AmmoMag58_CO.paa
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e1274db9cfcf8c453cbe99d9d611c34c635d6f2bdb693e62caef02afe2cfcbb2
-size 266992
+oid sha256:49961b79a28557cd39042b2686de5b3c8f2c271f62b07a1da516ca05a7c59e1d
+size 3249350

--- a/Addons/ADF_Weapons/adfrc_maximi/Textures/mk48_mod_0_camo_co.paa
+++ b/Addons/ADF_Weapons/adfrc_maximi/Textures/mk48_mod_0_camo_co.paa
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:743b3381c7f46b477ce54e56a82fda4c08c3638abc6aa7c383e83ec4f4ff6d88
-size 1024689
+oid sha256:6ac9597b640d9231e4714396b9cbd873ad714a59ce301707f7dba72c83be39fc
+size 1015731


### PR DESCRIPTION
Replaced belt box textures with the 'new' DPCU and Green textures as created a few months ago.

Tested and working in local environment.